### PR TITLE
chore: use HEAD arrow-go to avoid polars interop crash

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ go 1.25.0
 require (
 	github.com/adbc-drivers/driverbase-go/driverbase v0.0.0-20251112003129-9ec138f8c4cb
 	github.com/apache/arrow-adbc/go/adbc v1.9.0
-	github.com/apache/arrow-go/v18 v18.4.1
+	github.com/apache/arrow-go/v18 v18.4.2-0.20251124222331-4b04248429bc
 	github.com/google/uuid v1.6.0
 	github.com/snowflakedb/gosnowflake v1.18.0
 	github.com/stretchr/testify v1.11.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -24,8 +24,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-adbc/go/adbc v1.9.0 h1:0IE9mLhEDbpiiIN0Fprg8k/eeJBL9QS5lXCJSCahVlA=
 github.com/apache/arrow-adbc/go/adbc v1.9.0/go.mod h1:RzmPqbelrp8FA00rfRapek95jFp7EEDeZgoC2ozDPEI=
-github.com/apache/arrow-go/v18 v18.4.1 h1:q/jVkBWCJOB9reDgaIZIdruLQUb1kbkvOnOFezVH1C4=
-github.com/apache/arrow-go/v18 v18.4.1/go.mod h1:tLyFubsAl17bvFdUAy24bsSvA/6ww95Iqi67fTpGu3E=
+github.com/apache/arrow-go/v18 v18.4.2-0.20251124222331-4b04248429bc h1:Ynqz61WSogxuGjewXpo/PY2/6CIvwyCfT8hmdVIqD30=
+github.com/apache/arrow-go/v18 v18.4.2-0.20251124222331-4b04248429bc/go.mod h1:UCRktNZLefGn/LpFRklvQjTZrObjrSSwz1t923BO6VM=
 github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
 github.com/aws/aws-sdk-go-v2 v1.40.0 h1:/WMUA0kjhZExjOQN2z3oLALDREea1A7TobfuiBrKlwc=


### PR DESCRIPTION
## What's Changed

apache/arrow-go@41441ea911bf4d54d27c918ff0061ed71dca8a39 isn't in any released version.
