### PR TITLE
ci: add workflow to test a PR

### DIFF
--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -39,8 +39,16 @@ on:
       - "go/**"
       - .github/workflows/go_test.yaml
 
-  workflow_dispatch: {}
-
+  workflow_call:
+    inputs:
+      repository:
+        description: "The repository to checkout"
+        required: true
+        type: string
+      commit:
+        description: "The commit to checkout"
+        required: true
+        type: string
 
 concurrency:
   # Must share concurrency group with release workflow since it also builds/tests
@@ -74,7 +82,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name != 'workflow_dispatch'
         with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "checkout remote"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -172,7 +190,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name != 'workflow_dispatch'
         with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "checkout remote"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -279,7 +307,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name != 'workflow_dispatch'
         with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "checkout remote"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -332,7 +370,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name != 'workflow_dispatch'
         with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "checkout remote"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -399,7 +447,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name != 'workflow_dispatch'
         with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "checkout remote"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/go_test_pr.yaml
+++ b/.github/workflows/go_test_pr.yaml
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 ADBC Drivers Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# !!!! AUTO-GENERATED FILE.  DO NOT EDIT. !!!!
+# USE adbc-gen-workflow (see adbc-drivers/dev) TO UPDATE THIS FILE.
+
+name: Go Test PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "The PR to test"
+        required: true
+        type: string
+      commit:
+        description: "The commit to checkout"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ inputs.pr }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    name: configure job
+    runs-on: ubuntu-slim
+    outputs:
+      repository: ${{ steps.get_repo.outputs.repository }}
+    steps:
+      - name: get repository
+        id: get_repo
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo repository=$(gh pr --repo ${{ github.repository }} view ${{ inputs.pr }} --json headRepository,headRepositoryOwner --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"') | tee -a $GITHUB_OUTPUT
+
+      - name: set job summary
+        run: |
+          echo "**PR:** https://github.com/${{ github.repository }}/pull/${{ inputs.pr }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Remote:** ${{ steps.get_repo.outputs.repository }}@${{ inputs.commit }}" >> $GITHUB_STEP_SUMMARY
+
+  test:
+    uses: adbc-drivers/snowflake/.github/workflows/go_test.yaml@main
+    needs:
+      - setup
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      commit: ${{ inputs.commit }}
+
+  report:
+    name: comment on PR
+    runs-on: ubuntu-slim
+    if: ${{ always() }}
+    needs:
+      - setup
+      - test
+    permissions:
+      pull-requests: write
+    steps:
+      - id: get_run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo workflow_run_url=$(gh run --repo ${{ github.repository }} view ${{ github.run_id }} --json url --jq '.url') | tee -a $GITHUB_OUTPUT
+          if [[ '${{ needs.test.result }}' == 'success' ]]; then
+            echo message=":heavy_check_mark: **Test passed:** " | tee -a $GITHUB_OUTPUT
+          else
+            echo message=":x: **Test failed:** " | tee -a $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ inputs.pr }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ steps.get_run.outputs.message }} ${{ needs.setup.outputs.repository }}@${{ inputs.commit }}\nWorkflow run: ${{ steps.get_run.outputs.workflow_run_url }}'
+            })


### PR DESCRIPTION
## What's Changed

Add a workflow that a maintainer can invoke, which tests a PR (with credentials) and comments the result on the PR. I'll add this to the templates once we test it in this repo.
