### PR TITLE
ci: fix permissions for go_test_pr.yaml

### DIFF
--- a/.github/workflows/go_test_pr.yaml
+++ b/.github/workflows/go_test_pr.yaml
@@ -39,6 +39,7 @@ defaults:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   setup:


### PR DESCRIPTION
## What's Changed

Needs `packages: read`
