### PR TITLE
feat(go): support target catalog/schema in ingest

### DIFF
--- a/go/bulk_ingestion.go
+++ b/go/bulk_ingestion.go
@@ -149,7 +149,7 @@ func (st *statement) ingestRecord(ctx context.Context) (nrows int64, err error) 
 
 	var (
 		initialRows int64
-		target      = quoteTblName(st.targetTable)
+		target      = st.qualifiedTableName()
 	)
 
 	// Check final row count of target table to get definitive rows affected
@@ -233,7 +233,7 @@ func (st *statement) ingestStream(ctx context.Context) (nrows int64, err error) 
 
 	var (
 		initialRows int64
-		target      = quoteTblName(st.targetTable)
+		target      = st.qualifiedTableName()
 	)
 
 	// Check final row count of target table to get definitive rows affected

--- a/go/bulk_ingestion_test.go
+++ b/go/bulk_ingestion_test.go
@@ -88,6 +88,59 @@ func TestIngestBatchedParquetWithFileLimit(t *testing.T) {
 	require.ErrorIs(t, writeParquet(rdr.Schema(), &buf, records, -1, parquetProps, arrowProps), io.EOF)
 }
 
+func TestQualifiedTableName(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetCatalog  string
+		targetDbSchema string
+		targetTable    string
+		expected       string
+	}{
+		{
+			name:        "table only",
+			targetTable: "my_table",
+			expected:    `"my_table"`,
+		},
+		{
+			name:           "schema and table (2-part)",
+			targetDbSchema: "my_schema",
+			targetTable:    "my_table",
+			expected:       `"my_schema"."my_table"`,
+		},
+		{
+			name:           "catalog, schema, and table (3-part)",
+			targetCatalog:  "my_catalog",
+			targetDbSchema: "my_schema",
+			targetTable:    "my_table",
+			expected:       `"my_catalog"."my_schema"."my_table"`,
+		},
+		{
+			name:          "catalog and table (no schema)",
+			targetCatalog: "my_catalog",
+			targetTable:   "my_table",
+			expected:      `"my_catalog"."my_table"`,
+		},
+		{
+			name:           "identifiers with special characters",
+			targetCatalog:  `my"catalog`,
+			targetDbSchema: `my"schema`,
+			targetTable:    `my"table`,
+			expected:       `"my""catalog"."my""schema"."my""table"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &statement{
+				targetCatalog:  tt.targetCatalog,
+				targetDbSchema: tt.targetDbSchema,
+				targetTable:    tt.targetTable,
+			}
+			assert.Equal(t, tt.expected, st.qualifiedTableName())
+		})
+	}
+}
+
 func makeRec(mem memory.Allocator, nCols, nRows int) arrow.RecordBatch {
 	vals := make([]int8, nRows)
 	for val := range nRows {

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -2538,6 +2538,91 @@ func TestIngestCancelContext(t *testing.T) {
 	})
 }
 
+func TestIngestWithQualifiedTableName(t *testing.T) {
+	withQuirks(t, func(q *SnowflakeQuirks) {
+		ctx := context.Background()
+
+		drv := q.SetupDriver(t)
+		defer q.TearDownDriver(t, drv)
+
+		db, err := drv.NewDatabase(q.DatabaseOptions())
+		require.NoError(t, err)
+
+		cnxn, err := db.Open(ctx)
+		require.NoError(t, err)
+
+		sc := arrow.NewSchema([]arrow.Field{
+			{Name: "col_int64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		}, nil)
+
+		bldr := array.NewRecordBuilder(q.Alloc(), sc)
+		defer bldr.Release()
+
+		bldr.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2, 3}, nil)
+
+		rec := bldr.NewRecordBatch()
+		defer rec.Release()
+
+		// Test 2-part name: schema.table
+		t.Run("schema_qualified", func(t *testing.T) {
+			tblName := "bulk_ingest_schema_qualified"
+			require.NoError(t, q.DropTable(cnxn, tblName))
+
+			stmt, err := cnxn.NewStatement()
+			require.NoError(t, err)
+
+			require.NoError(t, stmt.Bind(ctx, rec))
+			require.NoError(t, stmt.SetOption(adbc.OptionKeyIngestTargetTable, tblName))
+			require.NoError(t, stmt.SetOption(adbc.OptionValueIngestTargetDBSchema, q.DBSchema()))
+
+			n, err := stmt.ExecuteUpdate(ctx)
+			require.NoError(t, err)
+			require.EqualValues(t, 3, n)
+
+			require.NoError(t, stmt.SetSqlQuery(fmt.Sprintf(`SELECT * FROM "%s"."%s" ORDER BY "col_int64" ASC`, q.DBSchema(), tblName)))
+			rdr, _, err := stmt.ExecuteQuery(ctx)
+			require.NoError(t, err)
+			defer rdr.Release()
+			require.True(t, rdr.Next())
+			require.EqualValues(t, 3, rdr.RecordBatch().NumRows())
+
+			require.NoError(t, stmt.Close())
+			require.NoError(t, q.DropTable(cnxn, tblName))
+		})
+
+		// Test 3-part name: catalog.schema.table
+		t.Run("catalog_and_schema_qualified", func(t *testing.T) {
+			tblName := "bulk_ingest_fully_qualified"
+			require.NoError(t, q.DropTable(cnxn, tblName))
+
+			stmt, err := cnxn.NewStatement()
+			require.NoError(t, err)
+
+			require.NoError(t, stmt.Bind(ctx, rec))
+			require.NoError(t, stmt.SetOption(adbc.OptionKeyIngestTargetTable, tblName))
+			require.NoError(t, stmt.SetOption(adbc.OptionValueIngestTargetCatalog, q.Catalog()))
+			require.NoError(t, stmt.SetOption(adbc.OptionValueIngestTargetDBSchema, q.DBSchema()))
+
+			n, err := stmt.ExecuteUpdate(ctx)
+			require.NoError(t, err)
+			require.EqualValues(t, 3, n)
+
+			require.NoError(t, stmt.SetSqlQuery(fmt.Sprintf(`SELECT * FROM "%s"."%s"."%s" ORDER BY "col_int64" ASC`, q.Catalog(), q.DBSchema(), tblName)))
+			rdr, _, err := stmt.ExecuteQuery(ctx)
+			require.NoError(t, err)
+			defer rdr.Release()
+			require.True(t, rdr.Next())
+			require.EqualValues(t, 3, rdr.RecordBatch().NumRows())
+
+			require.NoError(t, stmt.Close())
+			require.NoError(t, q.DropTable(cnxn, tblName))
+		})
+
+		require.NoError(t, cnxn.Close())
+		require.NoError(t, db.Close())
+	})
+}
+
 func (suite *SnowflakeTests) TestChangeDatabaseAndGetObjects() {
 	// this test demonstrates:
 	// 1. changing the database context

--- a/go/statement.go
+++ b/go/statement.go
@@ -62,9 +62,11 @@ type statement struct {
 	useHighPrecision      bool
 	maxTimestampPrecision MaxTimestampPrecision
 
-	query         string
-	targetTable   string
-	ingestMode    string
+	query           string
+	targetTable     string
+	targetCatalog   string
+	targetDbSchema  string
+	ingestMode      string
 	ingestOptions *ingestOptions
 	queryTag      string
 
@@ -74,6 +76,20 @@ type statement struct {
 
 func (st *statement) Base() *driverbase.StatementImplBase {
 	return &st.StatementImplBase
+}
+
+// qualifiedTableName builds a fully-qualified table identifier from the
+// configured catalog, schema, and table name.
+func (st *statement) qualifiedTableName() string {
+	parts := make([]string, 0, 3)
+	if st.targetCatalog != "" {
+		parts = append(parts, quoteTblName(st.targetCatalog))
+	}
+	if st.targetDbSchema != "" {
+		parts = append(parts, quoteTblName(st.targetDbSchema))
+	}
+	parts = append(parts, quoteTblName(st.targetTable))
+	return strings.Join(parts, ".")
 }
 
 // setQueryContext applies the query tag if present.
@@ -148,6 +164,10 @@ func (st *statement) SetOption(key string, val string) error {
 	case adbc.OptionKeyIngestTargetTable:
 		st.query = ""
 		st.targetTable = val
+	case adbc.OptionValueIngestTargetCatalog:
+		st.targetCatalog = val
+	case adbc.OptionValueIngestTargetDBSchema:
+		st.targetDbSchema = val
 	case adbc.OptionKeyIngestMode:
 		switch val {
 		case adbc.OptionValueIngestModeAppend:
@@ -405,7 +425,7 @@ func (st *statement) initIngest(ctx context.Context) error {
 	if st.ingestMode == adbc.OptionValueIngestModeCreateAppend {
 		createBldr.WriteString(" IF NOT EXISTS ")
 	}
-	createBldr.WriteString(quoteTblName(st.targetTable))
+	createBldr.WriteString(st.qualifiedTableName())
 	createBldr.WriteString(" (")
 
 	var schema *arrow.Schema
@@ -442,7 +462,7 @@ func (st *statement) initIngest(ctx context.Context) error {
 	case adbc.OptionValueIngestModeAppend:
 		// Do nothing
 	case adbc.OptionValueIngestModeReplace:
-		replaceQuery := "DROP TABLE IF EXISTS " + quoteTblName(st.targetTable)
+		replaceQuery := "DROP TABLE IF EXISTS " + st.qualifiedTableName()
 		_, err := st.cnxn.cn.ExecContext(ctx, replaceQuery, nil)
 		if err != nil {
 			return errToAdbcErr(adbc.StatusInternal, err)

--- a/go/statement.go
+++ b/go/statement.go
@@ -62,13 +62,13 @@ type statement struct {
 	useHighPrecision      bool
 	maxTimestampPrecision MaxTimestampPrecision
 
-	query           string
-	targetTable     string
-	targetCatalog   string
-	targetDbSchema  string
-	ingestMode      string
-	ingestOptions *ingestOptions
-	queryTag      string
+	query          string
+	targetTable    string
+	targetCatalog  string
+	targetDbSchema string
+	ingestMode     string
+	ingestOptions  *ingestOptions
+	queryTag       string
 
 	bound      arrow.RecordBatch
 	streamBind array.RecordReader


### PR DESCRIPTION
## What's Changed

Adds support for the standard ADBC `adbc.ingest.target_catalog` and
`adbc.ingest.target_db_schema` options in the Go Snowflake driver. When set,
the driver builds a fully-qualified table identifier (e.g.
`"catalog"."schema"."table"`) for all ingestion operations including
`CREATE TABLE`, `DROP TABLE IF EXISTS`, `COPY INTO`, and row count queries.

Previously, ingestion only used the unqualified table name, requiring users to
connect directly to the target database and schema. With this change, users can
ingest into any `database.schema.table` from any connection context.

Closes #94.