### PR TITLE
fix(go): number(38, 11) crashes when UseHighPrecision is false

### DIFF
--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -127,9 +127,7 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 				} else {
 					if srcMeta.Scale != 0 {
 						f.Type = arrow.PrimitiveTypes.Float64
-						// For precisions of 16, 17 and 18, a conversion from int64 to float64 fails with an error
-						// So for these precisions, we instead convert first to a decimal128 and then to a float64.
-						if srcMeta.Precision > 15 && srcMeta.Precision < 19 {
+						if srcMeta.Precision > 15 {
 							transformers[i] = func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
 								result, err := integerToDecimal128(ctx, a, &arrow.Decimal128Type{
 									Precision: int32(srcMeta.Precision),

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -127,31 +127,7 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 				} else {
 					if srcMeta.Scale != 0 {
 						f.Type = arrow.PrimitiveTypes.Float64
-						if srcMeta.Precision > 15 {
-							transformers[i] = func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
-								result, err := integerToDecimal128(ctx, a, &arrow.Decimal128Type{
-									Precision: int32(srcMeta.Precision),
-									Scale:     int32(srcMeta.Scale),
-								})
-								if err != nil {
-									return nil, err
-								}
-								defer result.Release()
-								return compute.CastArray(ctx, result, compute.UnsafeCastOptions(f.Type))
-							}
-						} else {
-							// For precisions less than 16, we can simply scale the integer value appropriately
-							transformers[i] = func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
-								result, err := compute.Divide(ctx, compute.ArithmeticOptions{NoCheckOverflow: true},
-									&compute.ArrayDatum{Value: a.Data()},
-									compute.NewDatum(math.Pow10(int(srcMeta.Scale))))
-								if err != nil {
-									return nil, err
-								}
-								defer result.Release()
-								return result.(*compute.ArrayDatum).MakeArray(), nil
-							}
-						}
+						transformers[i] = fixedToFloat64Transformer(int32(srcMeta.Precision), int32(srcMeta.Scale))
 					} else {
 						f.Type = arrow.PrimitiveTypes.Int64
 						transformers[i] = func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
@@ -340,6 +316,47 @@ func getArrowTimestampFromTime(val time.Time, unit arrow.TimeUnit, originalArrow
 	}
 
 	return arrow.TimestampFromTime(val, unit)
+}
+
+// fixedToFloat64Transformer returns the column transformer used by getTransformer
+// for FIXED Snowflake columns when useHighPrecision=false and scale != 0.
+//
+// Snowflake transmits FIXED columns as int64 on the wire. For precisions > 15 the
+// unscaled value can exceed 2^53, so the simple compute.Divide path (which performs
+// a safe int64->float64 cast) fails. In that case we widen to Decimal128 first.
+// For precisions <= 15 the unscaled value safely fits in float64, so we just scale
+// the integer directly.
+func fixedToFloat64Transformer(precision, scale int32) colTransformer {
+	if precision > 15 {
+		return scaledIntToFloat64Transformer(precision, scale)
+	}
+	return func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
+		result, err := compute.Divide(ctx, compute.ArithmeticOptions{NoCheckOverflow: true},
+			&compute.ArrayDatum{Value: a.Data()},
+			compute.NewDatum(math.Pow10(int(scale))))
+		if err != nil {
+			return nil, err
+		}
+		defer result.Release()
+		return result.(*compute.ArrayDatum).MakeArray(), nil
+	}
+}
+
+// scaledIntToFloat64Transformer returns the column transformer used by
+// fixedToFloat64Transformer when precision > 15. It converts a Snowflake
+// scaled-integer column (transmitted as int64) to float64 by first widening to
+// Decimal128, avoiding the int64->float64 safe cast failure that occurs when the
+// unscaled value exceeds 2^53.
+func scaledIntToFloat64Transformer(precision, scale int32) colTransformer {
+	dt := &arrow.Decimal128Type{Precision: precision, Scale: scale}
+	return func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
+		result, err := integerToDecimal128(ctx, a, dt)
+		if err != nil {
+			return nil, err
+		}
+		defer result.Release()
+		return compute.CastArray(ctx, result, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
+	}
 }
 
 func integerToDecimal128(ctx context.Context, a arrow.Array, dt *arrow.Decimal128Type) (arrow.Array, error) {

--- a/go/record_reader_test.go
+++ b/go/record_reader_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
-	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
@@ -363,51 +362,70 @@ func TestReadBatchRecords_PartialRecordsReleasedOnRetry(t *testing.T) {
 	assert.EqualValues(t, 1, recs[0].NumRows())
 }
 
-// TestIntegerToDecimal128_LargeUnscaledValue is the regression test for the NUMBER(38, 11) crash.
+// TestFixedToFloat64Transformer covers the driver code path that was changed by
+// the NUMBER(38, 11) fix.
 //
-// When useHighPrecision=false, Snowflake sends the column as int64 on the wire.
-// Before the fix, the guard "Precision > 15 && Precision < 19" skipped the safe
-// decimal128 intermediate path for precision >= 19, causing compute.Divide to attempt
-// a direct int64→float64 safe cast. Arrow's safe cast rejects values outside
-// [-9007199254740992, 9007199254740992] (i.e. > 2^53), triggering:
+// getTransformer wires fixedToFloat64Transformer for every FIXED Snowflake column
+// with useHighPrecision=false and scale != 0. The function chooses between two
+// internal paths based on precision:
 //
-//	"invalid: integer value 42135425651100000 not in range: -9007199254740992 to 9007199254740992"
+//   - precision <= 15: scale the int64 in place via compute.Divide (the unscaled
+//     value safely fits in float64).
+//   - precision >  15: widen to Decimal128 first, because the unscaled int64 can
+//     exceed 2^53 and a direct int64->float64 safe cast would fail with
+//     "integer value ... not in range: -9007199254740992 to 9007199254740992".
 //
-// The fix removes the upper bound so any precision > 15 uses the decimal128 intermediate path.
-// This test verifies:
-//  1. integerToDecimal128 handles a large unscaled int64 value without error.
-//  2. The resulting Decimal128 can be cast to float64 to recover the original decimal.
-func TestIntegerToDecimal128_LargeUnscaledValue(t *testing.T) {
-	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer alloc.AssertSize(t, 0)
+// Before the fix the precision>15 path was gated by an extra "precision < 19"
+// upper bound, so NUMBER(p, s) columns with p >= 19 (e.g. NUMBER(38, 11)) fell
+// through to compute.Divide and crashed on any unscaled value > 2^53. This test
+// exercises both branches of the guard fixedToFloat64Transformer now owns.
+func TestFixedToFloat64Transformer(t *testing.T) {
+	cases := []struct {
+		name          string
+		precision     int32
+		scale         int32
+		unscaledValue int64
+		want          float64
+	}{
+		{
+			// Regression case: NUMBER(38, 11) with unscaled value > 2^53
+			// (9007199254740992). Pre-fix this crashed; post-fix it goes through
+			// the Decimal128 intermediate path.
+			name:          "precision38_unscaledExceeds2Pow53",
+			precision:     38,
+			scale:         11,
+			unscaledValue: 42135425651100000,
+			want:          421354.256511,
+		},
+		{
+			// Happy path that was always working: precision <= 15 uses the
+			// in-place compute.Divide path. Included to guard against the
+			// refactor accidentally rerouting small precisions.
+			name:          "precision10_compactValue",
+			precision:     10,
+			scale:         2,
+			unscaledValue: 12345,
+			want:          123.45,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer alloc.AssertSize(t, 0)
 
-	// 421354.25651100000 stored as NUMBER(38,11) → unscaled int64 = 42135425651100000
-	// This value exceeds 2^53 = 9007199254740992, so the old compute.Divide path crashed.
-	const unscaledValue = int64(42135425651100000)
-	const scale = int32(11)
-	const precision = int32(38)
+			bldr := array.NewInt64Builder(alloc)
+			defer bldr.Release()
+			bldr.Append(tc.unscaledValue)
+			int64Arr := bldr.NewInt64Array()
+			defer int64Arr.Release()
 
-	// Build an int64 Arrow array — exactly what Snowflake sends over the wire.
-	bldr := array.NewInt64Builder(alloc)
-	defer bldr.Release()
-	bldr.Append(unscaledValue)
-	int64Arr := bldr.NewInt64Array()
-	defer int64Arr.Release()
+			transformer := fixedToFloat64Transformer(tc.precision, tc.scale)
+			out, err := transformer(context.Background(), int64Arr)
+			require.NoError(t, err)
+			defer out.Release()
 
-	dt := &arrow.Decimal128Type{Precision: precision, Scale: scale}
-	ctx := context.Background()
-
-	// This is the path that the fixed code uses for precision > 15.
-	dec128Arr, err := integerToDecimal128(ctx, int64Arr, dt)
-	require.NoError(t, err, "integerToDecimal128 must succeed for large unscaled values")
-	defer dec128Arr.Release()
-
-	// Cast to float64 to get the final value (as the low-precision path does).
-	float64Arr, err := compute.CastArray(ctx, dec128Arr, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
-	require.NoError(t, err, "Decimal128→float64 cast must succeed")
-	defer float64Arr.Release()
-
-	got := float64Arr.(*array.Float64).Value(0)
-	// 42135425651100000 / 10^11 = 421354.256511
-	assert.InDelta(t, 421354.256511, got, 1e-4)
+			require.IsType(t, (*array.Float64)(nil), out)
+			assert.InDelta(t, tc.want, out.(*array.Float64).Value(0), 1e-4)
+		})
+	}
 }

--- a/go/record_reader_test.go
+++ b/go/record_reader_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
@@ -360,4 +361,53 @@ func TestReadBatchRecords_PartialRecordsReleasedOnRetry(t *testing.T) {
 	// The allocator check in defer will catch any leaked memory from the
 	// partial records of the failed first attempt.
 	assert.EqualValues(t, 1, recs[0].NumRows())
+}
+
+// TestIntegerToDecimal128_LargeUnscaledValue is the regression test for the NUMBER(38, 11) crash.
+//
+// When useHighPrecision=false, Snowflake sends the column as int64 on the wire.
+// Before the fix, the guard "Precision > 15 && Precision < 19" skipped the safe
+// decimal128 intermediate path for precision >= 19, causing compute.Divide to attempt
+// a direct int64→float64 safe cast. Arrow's safe cast rejects values outside
+// [-9007199254740992, 9007199254740992] (i.e. > 2^53), triggering:
+//
+//	"invalid: integer value 42135425651100000 not in range: -9007199254740992 to 9007199254740992"
+//
+// The fix removes the upper bound so any precision > 15 uses the decimal128 intermediate path.
+// This test verifies:
+//  1. integerToDecimal128 handles a large unscaled int64 value without error.
+//  2. The resulting Decimal128 can be cast to float64 to recover the original decimal.
+func TestIntegerToDecimal128_LargeUnscaledValue(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	// 421354.25651100000 stored as NUMBER(38,11) → unscaled int64 = 42135425651100000
+	// This value exceeds 2^53 = 9007199254740992, so the old compute.Divide path crashed.
+	const unscaledValue = int64(42135425651100000)
+	const scale = int32(11)
+	const precision = int32(38)
+
+	// Build an int64 Arrow array — exactly what Snowflake sends over the wire.
+	bldr := array.NewInt64Builder(alloc)
+	defer bldr.Release()
+	bldr.Append(unscaledValue)
+	int64Arr := bldr.NewInt64Array()
+	defer int64Arr.Release()
+
+	dt := &arrow.Decimal128Type{Precision: precision, Scale: scale}
+	ctx := context.Background()
+
+	// This is the path that the fixed code uses for precision > 15.
+	dec128Arr, err := integerToDecimal128(ctx, int64Arr, dt)
+	require.NoError(t, err, "integerToDecimal128 must succeed for large unscaled values")
+	defer dec128Arr.Release()
+
+	// Cast to float64 to get the final value (as the low-precision path does).
+	float64Arr, err := compute.CastArray(ctx, dec128Arr, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
+	require.NoError(t, err, "Decimal128→float64 cast must succeed")
+	defer float64Arr.Release()
+
+	got := float64Arr.(*array.Float64).Value(0)
+	// 42135425651100000 / 10^11 = 421354.256511
+	assert.InDelta(t, 421354.256511, got, 1e-4)
 }


### PR DESCRIPTION
Fix: NUMBER(38, 11) crash when use_high_precision=false
**Problem**
When querying a NUMBER(p, s) column with precision ≥ 19 and scale > 0 via the ADBC stack (Implementation="2.0") with use_high_precision=false, Snowflake sends the column as int64 on the Arrow wire (unscaled integer). The driver then attempted a direct int64 → float64 safe cast via compute.Divide, which Arrow rejects for values exceeding 2^53 (9,007,199,254,740,992):


[DataSource.Error] invalid: integer value 42135425651100000 not in range:-9007199254740992 to 9007199254740992
Root cause: In getTransformer (record_reader.go), the guard routing high-precision integers through the safe Decimal128 intermediate path was:


if srcMeta.Precision > 15 && srcMeta.Precision < 19  // ← missed precision ≥ 19

Any NUMBER(p, s) with p ≥ 19 and s > 0 fell through to the direct compute.Divide path, where unscaled values > 2^53 caused a range error.

**Fix**
Removed the incorrect upper bound in record_reader.go:


// Before
if srcMeta.Precision > 15 && srcMeta.Precision < 19
// After
if srcMeta.Precision > 15

Any NUMBER column with precision > 15 and scale > 0 now routes through the integerToDecimal128 intermediate path: int64 → Decimal128(20,0) (no range issue) → type metadata substituted to Decimal128(p,s) → UnsafeCast to float64. This avoids Arrow's safe-cast range check entirely.

**Test**
Added TestIntegerToDecimal128_LargeUnscaledValue in record_reader_test.go which directly verifies that a NUMBER(38, 11) unscaled value of 42135425651100000 (representing 421354.256511, exceeding 2^53) is correctly converted to float64 without error.

