### PR TITLE
fix(go): preserve reader errors and reject truncated streams

### DIFF
--- a/go/concat_reader.go
+++ b/go/concat_reader.go
@@ -97,6 +97,10 @@ func (r *concatReader) Schema() *arrow.Schema {
 }
 func (r *concatReader) Next() bool {
 	for r.currentReader != nil && !r.currentReader.Next() {
+		if err := r.currentReader.Err(); err != nil {
+			r.err = err
+			break
+		}
 		r.nextReader()
 	}
 	if r.currentReader == nil || r.err != nil {

--- a/go/concat_reader_test.go
+++ b/go/concat_reader_test.go
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2025 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReaderIter struct {
+	readers   []array.RecordReader
+	nextCalls int
+}
+
+func (m *mockReaderIter) Release() {}
+
+func (m *mockReaderIter) Next() (array.RecordReader, error) {
+	m.nextCalls++
+	if len(m.readers) == 0 {
+		return nil, io.EOF
+	}
+	reader := m.readers[0]
+	m.readers = m.readers[1:]
+	return reader, nil
+}
+
+type mockRecordReader struct {
+	schema *arrow.Schema
+	next   []bool
+	err    error
+}
+
+func (m *mockRecordReader) Release() {}
+
+func (m *mockRecordReader) Retain() {}
+
+func (m *mockRecordReader) Schema() *arrow.Schema {
+	return m.schema
+}
+
+func (m *mockRecordReader) Next() bool {
+	if len(m.next) == 0 {
+		return false
+	}
+	result := m.next[0]
+	m.next = m.next[1:]
+	return result
+}
+
+func (m *mockRecordReader) Record() arrow.RecordBatch {
+	return nil
+}
+
+func (m *mockRecordReader) RecordBatch() arrow.RecordBatch {
+	return nil
+}
+
+func (m *mockRecordReader) Err() error {
+	return m.err
+}
+
+func TestConcatReaderPreservesInnerReaderError(t *testing.T) {
+	innerErr := errors.New("inner reader failed")
+	iter := &mockReaderIter{
+		readers: []array.RecordReader{
+			&mockRecordReader{
+				schema: testSchema(),
+				next:   []bool{false},
+				err:    innerErr,
+			},
+			&mockRecordReader{
+				schema: testSchema(),
+				next:   []bool{false},
+			},
+		},
+	}
+
+	rdr := &concatReader{}
+	require.NoError(t, rdr.Init(iter))
+	defer rdr.Release()
+
+	assert.False(t, rdr.Next())
+	require.Error(t, rdr.Err())
+	assert.ErrorIs(t, rdr.Err(), innerErr)
+	assert.Equal(t, 1, iter.nextCalls, "concatReader should not advance past a failing inner reader")
+}

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -34,6 +34,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -770,9 +771,28 @@ type reader struct {
 	curChIndex int
 	rec        arrow.RecordBatch
 	err        error
+	errMu      sync.Mutex
+	errOnce    sync.Once
 
 	cancelFn context.CancelFunc
 	done     chan struct{} // signals all producer goroutines have finished
+}
+
+func (r *reader) setErr(err error) {
+	if err == nil {
+		return
+	}
+	r.errOnce.Do(func() {
+		r.errMu.Lock()
+		r.err = err
+		r.errMu.Unlock()
+	})
+}
+
+func (r *reader) getErr() error {
+	r.errMu.Lock()
+	defer r.errMu.Unlock()
+	return r.err
 }
 
 const defaultStreamMaxRetries = 3
@@ -780,6 +800,7 @@ const defaultStreamMaxRetries = 3
 // batchStreamer is the subset of gosnowflake.ArrowStreamBatch needed for reading.
 type batchStreamer interface {
 	GetStream(ctx context.Context) (io.ReadCloser, error)
+	NumRows() int64
 }
 
 // countingReadCloser wraps an io.ReadCloser and counts bytes read.
@@ -797,6 +818,60 @@ func (c *countingReadCloser) Read(p []byte) (int, error) {
 
 func (c *countingReadCloser) Close() error {
 	return c.inner.Close()
+}
+
+func rowCountMismatchError(scope string, expectedRows, actualRows int64) error {
+	return errToAdbcErr(adbc.StatusInvalidData, fmt.Errorf(
+		"%s row count mismatch: expected %d rows, got %d",
+		scope,
+		expectedRows,
+		actualRows,
+	))
+}
+
+func validateRowCount(scope string, expectedRows, actualRows int64) error {
+	if expectedRows != actualRows {
+		return rowCountMismatchError(scope, expectedRows, actualRows)
+	}
+	return nil
+}
+
+func finalizeBatchRead(ctx context.Context, scope string, expectedRows, actualRows int64, readerErr error) error {
+	if readerErr != nil {
+		return readerErr
+	}
+	// rr.Next() performs one more read after the last emitted record to confirm
+	// stream completion. If cancellation lands during that final probe after at
+	// least one row was already emitted, an exact row-count match still means the
+	// batch completed successfully.
+	rowCountErr := validateRowCount(scope, expectedRows, actualRows)
+	if rowCountErr == nil {
+		if ctxErr := ctx.Err(); ctxErr != nil && actualRows == 0 {
+			return ctxErr
+		}
+		return nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil && actualRows < expectedRows {
+		return ctxErr
+	}
+	return rowCountErr
+}
+
+type batchStreamTarget struct {
+	scope           string
+	expectedRows    int64
+	initialRowsRead int64
+	out             chan<- arrow.RecordBatch
+	totalRowsRead   *atomic.Int64
+}
+
+func newBatchStreamTarget(batchIdx int, batch batchStreamer, out chan<- arrow.RecordBatch, totalRowsRead *atomic.Int64) batchStreamTarget {
+	return batchStreamTarget{
+		scope:         fmt.Sprintf("batch[%d]", batchIdx),
+		expectedRows:  batch.NumRows(),
+		out:           out,
+		totalRowsRead: totalRowsRead,
+	}
 }
 
 // readBatchRecords reads all Arrow records from a Snowflake batch with retries.
@@ -849,6 +924,7 @@ func tryReadBatch(ctx context.Context, batch batchStreamer, alloc memory.Allocat
 	}
 	defer rr.Release()
 
+	var rowsRead int64
 	for rr.Next() && ctx.Err() == nil {
 		rec := rr.RecordBatch()
 		rec, err = transform(ctx, rec)
@@ -856,14 +932,79 @@ func tryReadBatch(ctx context.Context, batch batchStreamer, alloc memory.Allocat
 			return recs, err
 		}
 		recs = append(recs, rec)
+		rowsRead += rec.NumRows()
 	}
-	if err = rr.Err(); err != nil {
+	if err = finalizeBatchRead(ctx, "batch stream", batch.NumRows(), rowsRead, rr.Err()); err != nil {
 		return recs, err
 	}
-	if ctx.Err() != nil {
-		return recs, ctx.Err()
-	}
 	return recs, nil
+}
+
+func streamRecordReaderToChannel(
+	ctx context.Context,
+	rr *ipc.Reader,
+	transform recordTransformer,
+	target batchStreamTarget,
+) error {
+	rowsRead := target.initialRowsRead
+	for rr.Next() && ctx.Err() == nil {
+		rec := rr.RecordBatch()
+		rec, err := transform(ctx, rec)
+		if err != nil {
+			return err
+		}
+		select {
+		case target.out <- rec:
+			rowsRead += rec.NumRows()
+			if target.totalRowsRead != nil {
+				target.totalRowsRead.Add(rec.NumRows())
+			}
+		case <-ctx.Done():
+			rec.Release()
+			return ctx.Err()
+		}
+	}
+	return finalizeBatchRead(ctx, target.scope, target.expectedRows, rowsRead, rr.Err())
+}
+
+func streamBatchToChannel(
+	ctx context.Context,
+	batchIdx int,
+	batch batchStreamer,
+	alloc memory.Allocator,
+	transform recordTransformer,
+	target batchStreamTarget,
+) (err error) {
+	rawStream, err := batch.GetStream(ctx)
+	if err != nil {
+		trace.SpanFromContext(ctx).AddEvent("batch.GetStream.failed", trace.WithAttributes(
+			attribute.Int("batchIndex", batchIdx),
+			attribute.String("error", err.Error()),
+		))
+		return err
+	}
+	countingStream := &countingReadCloser{inner: rawStream}
+	defer func() {
+		err = errors.Join(err, countingStream.Close())
+	}()
+
+	rr, err := ipc.NewReader(countingStream, ipc.WithAllocator(alloc))
+	if err != nil {
+		trace.SpanFromContext(ctx).AddEvent("batch.ipcReader.failed", trace.WithAttributes(
+			attribute.Int("batchIndex", batchIdx),
+			attribute.Int64("bytesRead", countingStream.bytesRead),
+			attribute.String("error", err.Error()),
+		))
+		return fmt.Errorf("batch[%d]: ipc.NewReader failed after reading %d bytes: %w", batchIdx, countingStream.bytesRead, err)
+	}
+	defer rr.Release()
+
+	return streamRecordReaderToChannel(
+		ctx,
+		rr,
+		transform,
+		target,
+	)
 }
 
 // readJSONBatches handles the case where GetBatches() returned downloadable
@@ -887,7 +1028,7 @@ func readJSONBatches(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		}
 	}
 
-	if ld.TotalRows() == 0 {
+	if ld.TotalRows() == 0 && len(batches) == 0 {
 		return array.NewRecordReader(schema, []arrow.RecordBatch{})
 	}
 
@@ -896,6 +1037,7 @@ func readJSONBatches(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 
 	var results []arrow.RecordBatch
 	var rawData [][]*string
+	var totalRowsRead int64
 	for batchIdx, b := range batches {
 		var data []byte
 		if batchIdx == 0 {
@@ -961,8 +1103,12 @@ func readJSONBatches(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		defer rec.Release()
 
 		results = append(results, rec)
+		totalRowsRead += rec.NumRows()
 	}
 
+	if err := validateRowCount("result set", ld.TotalRows(), totalRowsRead); err != nil {
+		return nil, err
+	}
 	return array.NewRecordReader(schema, results)
 }
 
@@ -986,7 +1132,7 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 			}
 		}
 
-		if ld.TotalRows() == 0 {
+		if ld.TotalRows() == 0 && len(rawData) == 0 && len(batches) == 0 {
 			return array.NewRecordReader(schema, []arrow.RecordBatch{})
 		}
 
@@ -1000,6 +1146,7 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		defer rec.Release()
 
 		results := []arrow.RecordBatch{rec}
+		totalRowsRead := rec.NumRows()
 		for _, b := range batches {
 			rdr, err := b.GetStream(ctx)
 			if err != nil {
@@ -1066,13 +1213,20 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 			defer rec.Release()
 
 			results = append(results, rec)
+			totalRowsRead += rec.NumRows()
 		}
 
+		if err := validateRowCount("result set", ld.TotalRows(), totalRowsRead); err != nil {
+			return nil, err
+		}
 		return array.NewRecordReader(schema, results)
 	}
 
 	// Handle empty batches case early
 	if len(batches) == 0 {
+		if err := validateRowCount("result set", ld.TotalRows(), 0); err != nil {
+			return nil, err
+		}
 		schema, err := rowTypesToArrowSchema(ctx, ld, useHighPrecision, maxTimestampPrecision)
 		if err != nil {
 			return nil, err
@@ -1169,6 +1323,8 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 
 	var recTransform recordTransformer
 	rdr.schema, recTransform = getTransformer(rr.Schema(), ld, useHighPrecision, maxTimestampPrecision, geoCols)
+	var totalRowsRead atomic.Int64
+	batch0Target := newBatchStreamTarget(0, &batches[0], chs[0], &totalRowsRead)
 
 	if firstRec != nil {
 		transformed, err := recTransform(ctx, firstRec)
@@ -1180,35 +1336,26 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		}
 		// chs[0] is buffered (bufferSize >= 1), so this never blocks.
 		chs[0] <- transformed
+		rows := transformed.NumRows()
+		totalRowsRead.Add(rows)
+		batch0Target.initialRowsRead = rows
 	}
 
 	group.Go(func() (err error) {
 		defer rr.Release()
 		defer func() {
+			rdr.setErr(err)
 			err = errors.Join(err, r.Close())
 		}()
 		if len(batches) > 1 {
 			defer close(chs[0])
 		}
-
-		for rr.Next() && ctx.Err() == nil {
-			rec := rr.RecordBatch()
-			rec, err = recTransform(ctx, rec)
-			if err != nil {
-				return err
-			}
-
-			// Use context-aware send to prevent deadlock
-			select {
-			case chs[0] <- rec:
-				// Successfully sent
-			case <-ctx.Done():
-				// Context cancelled, clean up and exit
-				rec.Release()
-				return ctx.Err()
-			}
-		}
-		return rr.Err()
+		return streamRecordReaderToChannel(
+			ctx,
+			rr,
+			recTransform,
+			batch0Target,
+		)
 	})
 
 	lastChannelIndex := len(chs) - 1
@@ -1218,6 +1365,9 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 			// Channels already initialized above, no need to create them here
 			group.Go(func(batch batchStreamer, batchIdx int) func() error {
 				return func() (err error) {
+					defer func() {
+						rdr.setErr(err)
+					}()
 					// close channels (except the last) so that Next can move on to the next channel properly
 					if batchIdx != lastChannelIndex {
 						defer close(chs[batchIdx])
@@ -1239,6 +1389,7 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 						for i, rec := range recs {
 							select {
 							case chs[batchIdx] <- rec:
+								totalRowsRead.Add(rec.NumRows())
 								recs[i] = nil // ownership transferred to channel
 							case <-ctx.Done():
 								rec.Release()
@@ -1254,45 +1405,14 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 						return nil
 					}
 
-					// Original streaming path: read directly from stream without buffering
-					rawStream, err := batch.GetStream(ctx)
-					if err != nil {
-						trace.SpanFromContext(ctx).AddEvent("batch.GetStream.failed", trace.WithAttributes(
-							attribute.Int("batchIndex", batchIdx),
-							attribute.String("error", err.Error()),
-						))
-						return err
-					}
-					countingStream := &countingReadCloser{inner: rawStream}
-					defer func() {
-						err = errors.Join(err, countingStream.Close())
-					}()
-
-					rr, err := ipc.NewReader(countingStream, ipc.WithAllocator(alloc))
-					if err != nil {
-						trace.SpanFromContext(ctx).AddEvent("batch.ipcReader.failed", trace.WithAttributes(
-							attribute.Int("batchIndex", batchIdx),
-							attribute.Int64("bytesRead", countingStream.bytesRead),
-							attribute.String("error", err.Error()),
-						))
-						return fmt.Errorf("batch[%d]: ipc.NewReader failed after reading %d bytes: %w", batchIdx, countingStream.bytesRead, err)
-					}
-					defer rr.Release()
-
-					for rr.Next() && ctx.Err() == nil {
-						rec := rr.RecordBatch()
-						rec, err = recTransform(ctx, rec)
-						if err != nil {
-							return err
-						}
-						select {
-						case chs[batchIdx] <- rec:
-						case <-ctx.Done():
-							rec.Release()
-							return ctx.Err()
-						}
-					}
-					return rr.Err()
+					return streamBatchToChannel(
+						ctx,
+						batchIdx,
+						batch,
+						alloc,
+						recTransform,
+						newBatchStreamTarget(batchIdx, batch, chs[batchIdx], &totalRowsRead),
+					)
 				}
 			}(batch, batchIdx))
 		}
@@ -1301,7 +1421,10 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		// separate goroutine. Otherwise we'll have a race condition between
 		// the call to wait and the calls to group.Go to kick off the jobs
 		// to perform the pre-fetching (GH-1283).
-		rdr.err = group.Wait()
+		rdr.setErr(group.Wait())
+		if rdr.getErr() == nil {
+			rdr.setErr(validateRowCount("result set", ld.TotalRows(), totalRowsRead.Load()))
+		}
 		// don't close the last channel until after the group is finished,
 		// so that Next() can only return after reader.err may have been set
 		close(chs[lastChannelIndex])
@@ -1325,7 +1448,7 @@ func (r *reader) RecordBatch() arrow.RecordBatch {
 }
 
 func (r *reader) Err() error {
-	return r.err
+	return r.getErr()
 }
 
 func (r *reader) Next() bool {
@@ -1341,11 +1464,14 @@ func (r *reader) Next() bool {
 	var ok bool
 	for r.curChIndex < len(r.chs) {
 		if r.rec, ok = <-r.chs[r.curChIndex]; ok {
-			break
+			return true
+		}
+		if r.getErr() != nil {
+			return false
 		}
 		r.curChIndex++
 	}
-	return r.rec != nil
+	return false
 }
 
 func (r *reader) Retain() {

--- a/go/record_reader_test.go
+++ b/go/record_reader_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -32,8 +34,9 @@ import (
 
 // mockBatch implements batchStreamer for testing.
 type mockBatch struct {
-	streams []func() (io.ReadCloser, error)
+	streams []func(context.Context) (io.ReadCloser, error)
 	call    int
+	numRows int64
 }
 
 func (m *mockBatch) GetStream(ctx context.Context) (io.ReadCloser, error) {
@@ -42,7 +45,11 @@ func (m *mockBatch) GetStream(ctx context.Context) (io.ReadCloser, error) {
 	}
 	fn := m.streams[m.call]
 	m.call++
-	return fn()
+	return fn(ctx)
+}
+
+func (m *mockBatch) NumRows() int64 {
+	return m.numRows
 }
 
 // buildIPCBytes writes Arrow IPC record batches to a byte buffer.
@@ -54,6 +61,13 @@ func buildIPCBytes(alloc memory.Allocator, schema *arrow.Schema, records []arrow
 	}
 	_ = w.Close()
 	return buf.Bytes()
+}
+
+func truncateIPCStream(data []byte) []byte {
+	if len(data) <= 8 {
+		return append([]byte(nil), data...)
+	}
+	return append([]byte(nil), data[:len(data)-8]...)
 }
 
 func testSchema() *arrow.Schema {
@@ -82,16 +96,48 @@ func failingTransform(msg string) recordTransformer {
 	}
 }
 
-func streamFromBytes(data []byte) func() (io.ReadCloser, error) {
-	return func() (io.ReadCloser, error) {
+func streamFromBytes(data []byte) func(context.Context) (io.ReadCloser, error) {
+	return func(context.Context) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 }
 
-func streamError(err error) func() (io.ReadCloser, error) {
-	return func() (io.ReadCloser, error) {
+func streamError(err error) func(context.Context) (io.ReadCloser, error) {
+	return func(context.Context) (io.ReadCloser, error) {
 		return nil, err
 	}
+}
+
+type contextEOFStream struct {
+	ctx context.Context
+
+	prefix bytes.Reader
+
+	blockOnce sync.Once
+	blocked   chan struct{}
+}
+
+func newContextEOFStream(ctx context.Context, prefix []byte) *contextEOFStream {
+	return &contextEOFStream{
+		ctx:     ctx,
+		prefix:  *bytes.NewReader(prefix),
+		blocked: make(chan struct{}),
+	}
+}
+
+func (s *contextEOFStream) Read(p []byte) (int, error) {
+	if s.prefix.Len() > 0 {
+		return s.prefix.Read(p)
+	}
+	s.blockOnce.Do(func() {
+		close(s.blocked)
+	})
+	<-s.ctx.Done()
+	return 0, io.EOF
+}
+
+func (s *contextEOFStream) Close() error {
+	return nil
 }
 
 // --- tryReadBatch tests ---
@@ -105,7 +151,7 @@ func TestTryReadBatch_Success(t *testing.T) {
 	defer rec.Release()
 
 	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 3, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := tryReadBatch(context.Background(), batch, alloc, identityTransform)
 	require.NoError(t, err)
@@ -130,7 +176,7 @@ func TestTryReadBatch_MultipleRecords(t *testing.T) {
 	defer rec2.Release()
 
 	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec1, rec2})
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 4, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := tryReadBatch(context.Background(), batch, alloc, identityTransform)
 	require.NoError(t, err)
@@ -151,7 +197,7 @@ func TestTryReadBatch_EmptyStream(t *testing.T) {
 
 	schema := testSchema()
 	data := buildIPCBytes(alloc, schema, nil) // no records, just schema
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 0, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := tryReadBatch(context.Background(), batch, alloc, identityTransform)
 	require.NoError(t, err)
@@ -162,7 +208,7 @@ func TestTryReadBatch_GetStreamError(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)
 
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{streams: []func(context.Context) (io.ReadCloser, error){
 		streamError(fmt.Errorf("network down")),
 	}}
 
@@ -181,7 +227,7 @@ func TestTryReadBatch_TransformError(t *testing.T) {
 	defer rec.Release()
 
 	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 1, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := tryReadBatch(context.Background(), batch, alloc, failingTransform("bad transform"))
 	require.Error(t, err)
@@ -204,7 +250,7 @@ func TestTryReadBatch_CancelledContext(t *testing.T) {
 	defer rec.Release()
 
 	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 1, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := tryReadBatch(ctx, batch, alloc, identityTransform)
 	// Either GetStream or context check will surface the error
@@ -231,7 +277,7 @@ func TestReadBatchRecords_SuccessFirstAttempt(t *testing.T) {
 	defer rec.Release()
 
 	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){streamFromBytes(data)}}
+	batch := &mockBatch{numRows: 2, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
 
 	recs, err := readBatchRecords(context.Background(), batch, alloc, identityTransform, 3)
 	require.NoError(t, err)
@@ -252,7 +298,7 @@ func TestReadBatchRecords_SuccessAfterRetries(t *testing.T) {
 	goodData := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
 
 	// First two calls fail, third succeeds
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{numRows: 3, streams: []func(context.Context) (io.ReadCloser, error){
 		streamError(fmt.Errorf("fail 1")),
 		streamError(fmt.Errorf("fail 2")),
 		streamFromBytes(goodData),
@@ -271,7 +317,7 @@ func TestReadBatchRecords_ExhaustsRetries(t *testing.T) {
 	defer alloc.AssertSize(t, 0)
 
 	maxRetries := 2
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{streams: []func(context.Context) (io.ReadCloser, error){
 		streamError(fmt.Errorf("fail 1")),
 		streamError(fmt.Errorf("fail 2")),
 		streamError(fmt.Errorf("fail 3")),
@@ -288,7 +334,7 @@ func TestReadBatchRecords_ZeroRetries(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)
 
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{streams: []func(context.Context) (io.ReadCloser, error){
 		streamError(fmt.Errorf("only chance")),
 	}}
 
@@ -305,7 +351,7 @@ func TestReadBatchRecords_CancelledContextSkipsRetries(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{streams: []func(context.Context) (io.ReadCloser, error){
 		streamError(fmt.Errorf("should not reach")),
 	}}
 
@@ -347,7 +393,7 @@ func TestReadBatchRecords_PartialRecordsReleasedOnRetry(t *testing.T) {
 		return r, nil
 	}
 
-	batch := &mockBatch{streams: []func() (io.ReadCloser, error){
+	batch := &mockBatch{numRows: 1, streams: []func(context.Context) (io.ReadCloser, error){
 		streamFromBytes(failData),
 		streamFromBytes(goodData),
 	}}
@@ -427,5 +473,337 @@ func TestFixedToFloat64Transformer(t *testing.T) {
 			require.IsType(t, (*array.Float64)(nil), out)
 			assert.InDelta(t, tc.want, out.(*array.Float64).Value(0), 1e-4)
 		})
+	}
+}
+
+func TestReadBatchRecords_RetriesAfterRowCountMismatch(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	shortRec := buildTestRecord(alloc, schema, []int64{1})
+	defer shortRec.Release()
+	goodRec := buildTestRecord(alloc, schema, []int64{1, 2})
+	defer goodRec.Release()
+
+	shortData := buildIPCBytes(alloc, schema, []arrow.RecordBatch{shortRec})
+	goodData := buildIPCBytes(alloc, schema, []arrow.RecordBatch{goodRec})
+	batch := &mockBatch{numRows: 2, streams: []func(context.Context) (io.ReadCloser, error){
+		streamFromBytes(shortData),
+		streamFromBytes(goodData),
+	}}
+
+	recs, err := readBatchRecords(context.Background(), batch, alloc, identityTransform, 1)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	defer recs[0].Release()
+
+	assert.EqualValues(t, 2, recs[0].NumRows())
+	assert.Equal(t, 2, batch.call)
+}
+
+func TestTryReadBatch_TruncatedStreamFailsRowCountValidation(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	rec := buildTestRecord(alloc, schema, []int64{1})
+	defer rec.Release()
+
+	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
+	batch := &mockBatch{numRows: 3, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
+
+	recs, err := tryReadBatch(context.Background(), batch, alloc, identityTransform)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "batch stream row count mismatch: expected 3 rows, got 1")
+	for _, r := range recs {
+		r.Release()
+	}
+}
+
+func TestStreamBatchToChannel_TruncatedStreamFailsRowCountValidation(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	rec := buildTestRecord(alloc, schema, []int64{1})
+	defer rec.Release()
+
+	data := buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec})
+	batch := &mockBatch{numRows: 3, streams: []func(context.Context) (io.ReadCloser, error){streamFromBytes(data)}}
+	out := make(chan arrow.RecordBatch, 1)
+
+	err := streamBatchToChannel(context.Background(), 2, batch, alloc, identityTransform, newBatchStreamTarget(2, batch, out, nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "batch[2] row count mismatch: expected 3 rows, got 1")
+
+	select {
+	case rec := <-out:
+		assert.EqualValues(t, 1, rec.NumRows())
+		rec.Release()
+	default:
+		require.FailNow(t, "streamBatchToChannel should have emitted the partial record before reporting the row count mismatch")
+	}
+}
+
+func TestValidateRowCount_UsesNeutralMismatchMessage(t *testing.T) {
+	err := validateRowCount("result set", 5, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "result set row count mismatch: expected 5 rows, got 3")
+	assert.NotContains(t, err.Error(), "ended early")
+}
+
+func TestStreamBatchToChannel_CancellationReturnsContextError(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	schemaOnly := truncateIPCStream(buildIPCBytes(alloc, schema, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamCh := make(chan *contextEOFStream, 1)
+	batch := &mockBatch{
+		numRows: 0,
+		streams: []func(context.Context) (io.ReadCloser, error){
+			func(ctx context.Context) (io.ReadCloser, error) {
+				stream := newContextEOFStream(ctx, schemaOnly)
+				streamCh <- stream
+				return stream, nil
+			},
+		},
+	}
+
+	out := make(chan arrow.RecordBatch, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- streamBatchToChannel(ctx, 0, batch, alloc, identityTransform, newBatchStreamTarget(0, batch, out, nil))
+	}()
+
+	stream := <-streamCh
+	<-stream.blocked
+	cancel()
+
+	err := <-errCh
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReaderLateCancellationAfterLastRecordReturnsSuccess(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	rec := buildTestRecord(alloc, schema, []int64{1})
+	defer rec.Release()
+
+	recordThenBlockAtEOF := truncateIPCStream(buildIPCBytes(alloc, schema, []arrow.RecordBatch{rec}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	streamCh := make(chan *contextEOFStream, 1)
+	chs := []chan arrow.RecordBatch{make(chan arrow.RecordBatch, 1)}
+	rdr := &reader{
+		refCount: 1,
+		chs:      chs,
+		cancelFn: cancel,
+		done:     make(chan struct{}),
+	}
+
+	batch := &mockBatch{
+		numRows: 1,
+		streams: []func(context.Context) (io.ReadCloser, error){
+			func(ctx context.Context) (io.ReadCloser, error) {
+				stream := newContextEOFStream(ctx, recordThenBlockAtEOF)
+				streamCh <- stream
+				return stream, nil
+			},
+		},
+	}
+
+	go func() {
+		rdr.setErr(streamBatchToChannel(ctx, 0, batch, alloc, identityTransform, newBatchStreamTarget(0, batch, chs[0], nil)))
+		close(chs[0])
+		close(rdr.done)
+	}()
+
+	stream := <-streamCh
+	require.True(t, rdr.Next(), "reader should emit the completed batch before cancellation")
+	assert.EqualValues(t, 1, rdr.RecordBatch().NumRows())
+
+	<-stream.blocked
+	cancel()
+
+	nextCh := make(chan bool, 1)
+	go func() {
+		nextCh <- rdr.Next()
+	}()
+
+	select {
+	case got := <-nextCh:
+		assert.False(t, got)
+	case <-time.After(200 * time.Millisecond):
+		require.FailNow(t, "reader.Next should finish after late cancellation")
+	}
+
+	require.NoError(t, rdr.Err(), "late cancellation after the final batch should not surface as reader error")
+
+	releaseDone := make(chan struct{})
+	go func() {
+		rdr.Release()
+		close(releaseDone)
+	}()
+	select {
+	case <-releaseDone:
+	case <-time.After(200 * time.Millisecond):
+		require.FailNow(t, "reader.Release should not block after late cancellation")
+	}
+}
+
+func TestReaderStopsAfterEarlierBatchFailureDespiteLaterPrefetch(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	failingRec := buildTestRecord(alloc, schema, []int64{1})
+	defer failingRec.Release()
+	laterRec := buildTestRecord(alloc, schema, []int64{2})
+	defer laterRec.Release()
+
+	shortData := buildIPCBytes(alloc, schema, []arrow.RecordBatch{failingRec})
+	laterData := buildIPCBytes(alloc, schema, []arrow.RecordBatch{laterRec})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chs := []chan arrow.RecordBatch{
+		make(chan arrow.RecordBatch, 1),
+		make(chan arrow.RecordBatch, 1),
+	}
+	rdr := &reader{
+		refCount: 1,
+		chs:      chs,
+		cancelFn: cancel,
+		done:     make(chan struct{}),
+	}
+
+	failingBatch := &mockBatch{
+		numRows: 2,
+		streams: []func(context.Context) (io.ReadCloser, error){
+			streamFromBytes(shortData),
+		},
+	}
+	laterBatch := &mockBatch{
+		numRows: 1,
+		streams: []func(context.Context) (io.ReadCloser, error){
+			streamFromBytes(laterData),
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		err := streamBatchToChannel(ctx, 1, laterBatch, alloc, identityTransform, newBatchStreamTarget(1, laterBatch, chs[1], nil))
+		rdr.setErr(err)
+		close(chs[1])
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(chs[1]) == 1
+	}, 200*time.Millisecond, 10*time.Millisecond, "later batch should prefetch before the earlier batch fails")
+
+	go func() {
+		defer wg.Done()
+		err := streamBatchToChannel(ctx, 0, failingBatch, alloc, identityTransform, newBatchStreamTarget(0, failingBatch, chs[0], nil))
+		rdr.setErr(err)
+		close(chs[0])
+	}()
+
+	go func() {
+		wg.Wait()
+		close(rdr.done)
+	}()
+
+	require.True(t, rdr.Next(), "reader should emit the partial record from the failing batch first")
+	assert.EqualValues(t, 1, rdr.RecordBatch().NumRows())
+
+	assert.False(t, rdr.Next(), "reader should stop before yielding rows from later prefetched batches")
+	require.Error(t, rdr.Err())
+	assert.Contains(t, rdr.Err().Error(), "batch[0] row count mismatch: expected 2 rows, got 1")
+	assert.Len(t, chs[1], 1, "later prefetched rows should remain queued for release, not be returned by Next")
+
+	releaseDone := make(chan struct{})
+	go func() {
+		rdr.Release()
+		close(releaseDone)
+	}()
+	select {
+	case <-releaseDone:
+	case <-time.After(200 * time.Millisecond):
+		require.FailNow(t, "reader.Release should not block after suppressing later prefetched rows")
+	}
+}
+
+func TestReaderCancellationSetsErrBeforeNextAndReleaseReturns(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	schema := testSchema()
+	schemaOnly := truncateIPCStream(buildIPCBytes(alloc, schema, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	streamCh := make(chan *contextEOFStream, 1)
+	chs := []chan arrow.RecordBatch{make(chan arrow.RecordBatch)}
+	rdr := &reader{
+		refCount: 1,
+		chs:      chs,
+		cancelFn: cancel,
+		done:     make(chan struct{}),
+	}
+
+	batch := &mockBatch{
+		numRows: 0,
+		streams: []func(context.Context) (io.ReadCloser, error){
+			func(ctx context.Context) (io.ReadCloser, error) {
+				stream := newContextEOFStream(ctx, schemaOnly)
+				streamCh <- stream
+				return stream, nil
+			},
+		},
+	}
+
+	go func() {
+		rdr.setErr(streamBatchToChannel(ctx, 0, batch, alloc, identityTransform, newBatchStreamTarget(0, batch, chs[0], nil)))
+		close(chs[0])
+		close(rdr.done)
+	}()
+
+	nextCh := make(chan bool, 1)
+	go func() {
+		nextCh <- rdr.Next()
+	}()
+
+	stream := <-streamCh
+	<-stream.blocked
+	cancel()
+
+	select {
+	case got := <-nextCh:
+		assert.False(t, got)
+	case <-time.After(200 * time.Millisecond):
+		require.FailNow(t, "reader.Next should not block after cancellation")
+	}
+	require.Error(t, rdr.Err())
+	assert.ErrorIs(t, rdr.Err(), context.Canceled)
+
+	releaseDone := make(chan struct{})
+	go func() {
+		rdr.Release()
+		close(releaseDone)
+	}()
+	select {
+	case <-releaseDone:
+	case <-time.After(200 * time.Millisecond):
+		require.FailNow(t, "reader.Release should not block after cancellation")
 	}
 }


### PR DESCRIPTION
## What's Changed

Fixes two related failure modes in the Snowflake Arrow stream record
reader.

**Silent truncation.** A chunk download that ends prematurely
(mid-stream TCP RST from S3/Azure Blob, or a short read that the IPC
layer interprets as a clean end-of-stream) used to surface as
`Next() == false, Err() == nil`, hiding an incomplete result set. The
streaming, retrying, and JSON paths now share a `finalizeBatchRead`
helper that compares actual rows against `b.NumRows()` (per batch) and
`ld.TotalRows()` (per result set), so a short stream becomes an
`adbc.StatusInvalidData` error instead of a silent EOF.

**Cancellation correctness.** The producer goroutines now preserve
`rr.Err()` / `ctx.Err()` in every path, the reader latches the first
producer error before advancing channels (so later prefetched rows
don't leak after an earlier batch fails), and a late cancellation that
lands during the trailing `rr.Next()` completion probe — after every
expected row was emitted — is treated as success rather than a generic
error. `concatReader.Next()` also preserves a failing inner reader's
error instead of dropping it while stepping forward.

Companion upstream fixes already merged in gosnowflake:

- [#1792](https://github.com/snowflakedb/gosnowflake/pull/1792) — adds
  `ArrowStreamBatch.Reset()` (mirrors @davidhcoe's
  [#1782](https://github.com/snowflakedb/gosnowflake/pull/1782)).
- [#1795](https://github.com/snowflakedb/gosnowflake/pull/1795) —
  cancel-aware reader so an in-flight body read unblocks promptly and
  normalizes the close error to `ctx.Err()`.

This PR is independent of those; the next gosnowflake dependency bump
will be a separate change.

### Tests

`go test -tags assert -race -count=1 ./...` plus
`pre-commit run --all-files` are clean. New tests cover:

- `TestReadBatchRecords_RetriesAfterRowCountMismatch`
- `TestTryReadBatch_TruncatedStreamFailsRowCountValidation`
- `TestStreamBatchToChannel_TruncatedStreamFailsRowCountValidation`
- `TestStreamBatchToChannel_CancellationReturnsContextError`
- `TestReaderLateCancellationAfterLastRecordReturnsSuccess`
- `TestReaderStopsAfterEarlierBatchFailureDespiteLaterPrefetch`
- `TestReaderCancellationSetsErrBeforeNextAndReleaseReturns`
- `TestConcatReaderPreservesInnerReaderError`
- `TestValidateRowCount_UsesNeutralMismatchMessage`

Closes #133.