### PR TITLE
fix(go): rescale scale-9 timestamps in microseconds mode (#135)

### DIFF
--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -354,7 +354,7 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 			transformers[i] = func(ctx context.Context, a arrow.Array) (arrow.Array, error) {
 
 				if a.DataType().ID() != arrow.STRUCT {
-					return compute.CastArray(ctx, a, compute.SafeCastOptions(dt))
+					return castIntegerToTimestamp(ctx, a, dt, originalArrowUnit)
 				}
 
 				pool := compute.GetAllocator(ctx)
@@ -406,14 +406,7 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 						tb.Append(v)
 					}
 				} else {
-					for i, t := range a.(*array.Int64).Int64Values() {
-						if a.IsNull(i) {
-							tb.AppendNull()
-							continue
-						}
-
-						tb.Append(arrow.Timestamp(t))
-					}
+					return castIntegerToTimestamp(ctx, a, dt, originalArrowUnit)
 				}
 				return tb.NewArray(), nil
 			}
@@ -516,6 +509,51 @@ func getArrowTimestampFromTime(val time.Time, unit arrow.TimeUnit, originalArrow
 	}
 
 	return arrow.TimestampFromTime(val, unit)
+}
+
+// castIntegerToTimestamp converts a raw integer timestamp column (transmitted by
+// Snowflake as a single int64 in the column's native scale unit, originalArrowUnit)
+// to the target arrow timestamp type dt.
+//
+// Normally the native unit matches dt.Unit and the integer is reinterpreted in
+// place. When the "microseconds" max-precision option forces a scale-9
+// (nanosecond) column to a microsecond field type, the units differ; a plain
+// reinterpret would treat the nanosecond count as microseconds and inflate every
+// value 1000x (e.g. a 2017 timestamp becomes year 49704). In that case we rescale
+// by integer division, flooring toward negative infinity so the result matches
+// the struct path's time.Time/UnixMicro conversion (and unlike arrow's cast,
+// which truncates toward zero and would disagree by one unit for negative values
+// carrying sub-unit precision).
+func castIntegerToTimestamp(ctx context.Context, a arrow.Array, dt *arrow.TimestampType, originalArrowUnit arrow.TimeUnit) (arrow.Array, error) {
+	if dt.Unit == originalArrowUnit {
+		return compute.CastArray(ctx, a, compute.SafeCastOptions(dt))
+	}
+
+	// The only case where the units differ is a finer native unit downscaled to a
+	// coarser target (nanoseconds -> microseconds). Each coarser arrow.TimeUnit
+	// step is a factor of 1000.
+	divisor := int64(1)
+	for u := dt.Unit; u < originalArrowUnit; u++ {
+		divisor *= 1000
+	}
+
+	pool := compute.GetAllocator(ctx)
+	tb := array.NewTimestampBuilder(pool, dt)
+	defer tb.Release()
+
+	values := a.(*array.Int64).Int64Values()
+	for i, v := range values {
+		if a.IsNull(i) {
+			tb.AppendNull()
+			continue
+		}
+		scaled := v / divisor
+		if v%divisor != 0 && v < 0 {
+			scaled-- // floor toward negative infinity
+		}
+		tb.Append(arrow.Timestamp(scaled))
+	}
+	return tb.NewArray(), nil
 }
 
 // fixedToFloat64Transformer returns the column transformer used by getTransformer

--- a/go/record_reader_test.go
+++ b/go/record_reader_test.go
@@ -476,6 +476,81 @@ func TestFixedToFloat64Transformer(t *testing.T) {
 	}
 }
 
+func TestCastIntegerToTimestamp(t *testing.T) {
+	// 1506347332300000123 ns is 2017-09-25, with sub-microsecond digits (123).
+	const yr2017Ns int64 = 1506347332300000123
+
+	cases := []struct {
+		name              string
+		dt                *arrow.TimestampType
+		originalArrowUnit arrow.TimeUnit
+		input             int64
+		want              arrow.Timestamp
+	}{
+		{
+			// Regression for issue #135: a scale-9 (nanosecond) column delivered as
+			// a single int64 must be rescaled, not reinterpreted, when the
+			// "microseconds" option forces the field to timestamp[us]. Reinterpreting
+			// inflated the value 1000x (2017 -> year 49704).
+			name:              "scale9_microseconds_rescales",
+			dt:                &arrow.TimestampType{Unit: arrow.Microsecond},
+			originalArrowUnit: arrow.Nanosecond,
+			input:             yr2017Ns,
+			want:              arrow.Timestamp(yr2017Ns / 1000), // 1506347332300000, truncated
+		},
+		{
+			// Default nanoseconds mode: native unit matches the field unit, so the
+			// integer is reinterpreted unchanged.
+			name:              "scale9_nanoseconds_reinterprets",
+			dt:                &arrow.TimestampType{Unit: arrow.Nanosecond},
+			originalArrowUnit: arrow.Nanosecond,
+			input:             yr2017Ns,
+			want:              arrow.Timestamp(yr2017Ns),
+		},
+		{
+			// The timezone on the target type is preserved through the rescale.
+			name:              "ltz_microseconds_preservesTimeZone",
+			dt:                &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "America/Los_Angeles"},
+			originalArrowUnit: arrow.Nanosecond,
+			input:             yr2017Ns,
+			want:              arrow.Timestamp(yr2017Ns / 1000),
+		},
+		{
+			// A negative ns value carrying sub-microsecond digits floors toward
+			// negative infinity (-...233), matching the struct path's UnixMicro
+			// rather than truncating toward zero (-...232).
+			name:              "negative_microseconds_floors",
+			dt:                &arrow.TimestampType{Unit: arrow.Microsecond},
+			originalArrowUnit: arrow.Nanosecond,
+			input:             -6285681744183232512,
+			want:              arrow.Timestamp(-6285681744183233),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer alloc.AssertSize(t, 0)
+
+			bldr := array.NewInt64Builder(alloc)
+			defer bldr.Release()
+			bldr.Append(tc.input)
+			bldr.AppendNull()
+			in := bldr.NewInt64Array()
+			defer in.Release()
+
+			out, err := castIntegerToTimestamp(context.Background(), in, tc.dt, tc.originalArrowUnit)
+			require.NoError(t, err)
+			defer out.Release()
+
+			ts := out.(*array.Timestamp)
+			require.Equal(t, tc.dt.Unit, ts.DataType().(*arrow.TimestampType).Unit)
+			require.Equal(t, tc.dt.TimeZone, ts.DataType().(*arrow.TimestampType).TimeZone)
+			assert.Equal(t, tc.want, ts.Value(0))
+			assert.True(t, ts.IsNull(1), "null should be preserved")
+		})
+	}
+}
+
 func TestReadBatchRecords_RetriesAfterRowCountMismatch(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)


### PR DESCRIPTION
Fixes #135.

NOTE: As per my comment in the issue, it's still not clear exactly what's going on here. The Snowflake UI shows a timestamp of `49704-03-31 14:31:40.000` for this value. I'm trying to figure out how it was created.

## Problem

When `adbc.snowflake.sql.client_option.max_timestamp_precision = "microseconds"`, a scale-9 (nanosecond) `TIMESTAMP_NTZ`/`TIMESTAMP_LTZ` value could come back with a wildly wrong date — e.g. a 2017-09-25 timestamp surfacing as year 49704.

The issue originally pointed at the `time.UnixMicro(val.UnixMicro())` overflow in `getArrowTimestampFromTime`, but that turned out to be a red herring. The two numbers in the report are the **same instant**: `1506347332300000000` µs is year 49704, and that instant's nanosecond representation overflows int64 to exactly `-6285681744183232512`. The microsecond conversion wasn't overflowing — the `val` it received was already inflated 1000×.

## Root cause

For a scale-9 column, `getArrowTimeUnit(9, Microseconds)` makes the field type `timestamp[µs]`, but the column's native wire unit is nanoseconds. The struct decoding path rescales correctly (via `time.Time`/`UnixMicro`), but the **single-`int64` fast path** used `compute.CastArray`, which *reinterprets* the raw nanosecond integer as microseconds instead of dividing by 1000:

```
int64(1506347332300000000 ns)  --cast-->  timestamp[µs] = 1506347332300000000  // year 49704
```

This only affects scale 9 + microseconds mode; every other scale/mode has matching native and field units, so the reinterpret was already correct.

## Fix

Add `castIntegerToTimestamp`, used by both non-struct paths:

- When the native unit equals the field unit (every default-mode case), reinterpret the integer as before — no behavior change.
- When they differ (ns → µs), rescale by integer division, **flooring toward negative infinity** to match the struct path's `UnixMicro` semantics (arrow's cast truncates toward zero, which would disagree by one unit for negative values carrying sub-microsecond precision).

A value of `-6285681744183232512` ns now yields `-6285681744183233` µs — no error, no overflow.

## Tests

`TestCastIntegerToTimestamp` covers:
- scale-9 microseconds rescale (the regression — year 2017, not 49704)
- default nanoseconds reinterpret (unchanged)
- timezone preservation (LTZ)
- null preservation
- negative value floors to `-6285681744183233` (not `-6285681744183232`)

`go build`, `go vet`, and the unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)