### PR TITLE
test(csharp): add Statement.Cancel test

### DIFF
--- a/csharp/test/Interop/AdbcDrivers.Snowflake.Interop.Tests.csproj
+++ b/csharp/test/Interop/AdbcDrivers.Snowflake.Interop.Tests.csproj
@@ -3,36 +3,36 @@
     <TargetFrameworks Condition="'$(IsWindows)'=='true'">net8.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net8.0</TargetFrameworks>
   </PropertyGroup>
-    <ItemGroup>
-      <None Remove="Resources\SnowflakeConstraints.sql" />
-      <None Remove="Resources\SnowflakeData.sql" />
-    </ItemGroup>
-    <ItemGroup>
-      <EmbeddedResource Include="Resources\SnowflakeConstraints.sql">
-        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-      </EmbeddedResource>
-      <EmbeddedResource Include="Resources\SnowflakeData.sql">
-        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-      </EmbeddedResource>
-    </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-      <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Xunit.SkippableFact" Version="1.5.61"/>
-   </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\..\arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj" />
-      <ProjectReference Include="..\..\arrow-adbc\csharp\src\Client\Apache.Arrow.Adbc.Client.csproj" />
-      <ProjectReference Include="..\..\arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj" />
-      <ProjectReference Include="..\..\src\Interop\AdbcDrivers.Snowflake.Interop.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-     <None Update="Resources\snowflakeconfig.json">
-       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-     </None>
-   </ItemGroup>
- </Project>
+  <ItemGroup>
+    <None Remove="Resources\SnowflakeConstraints.sql" />
+    <None Remove="Resources\SnowflakeData.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\SnowflakeConstraints.sql">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\SnowflakeData.sql">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj" />
+    <ProjectReference Include="..\..\arrow-adbc\csharp\src\Client\Apache.Arrow.Adbc.Client.csproj" />
+    <ProjectReference Include="..\..\arrow-adbc\csharp\test\Apache.Arrow.Adbc.Tests\Apache.Arrow.Adbc.Testing.csproj" />
+    <ProjectReference Include="..\..\src\Interop\AdbcDrivers.Snowflake.Interop.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Resources\snowflakeconfig.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/csharp/test/Interop/AdbcDrivers.Snowflake.Interop.Tests.csproj
+++ b/csharp/test/Interop/AdbcDrivers.Snowflake.Interop.Tests.csproj
@@ -16,13 +16,13 @@
       </EmbeddedResource>
     </ItemGroup>
     <ItemGroup>
-     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-     <PackageReference Include="xunit" Version="2.9.3" />
-     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
-       <PrivateAssets>all</PrivateAssets>
-       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-     </PackageReference>
-     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61"/>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Xunit.SkippableFact" Version="1.5.61"/>
    </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\arrow-adbc\csharp\src\Apache.Arrow.Adbc\Apache.Arrow.Adbc.csproj" />

--- a/csharp/test/Interop/Resources/snowflakeconfig.json
+++ b/csharp/test/Interop/Resources/snowflakeconfig.json
@@ -16,11 +16,12 @@
         "auth_oauth": {
             "token": ""
         },
-        "auth_jwt": {
-            "private_key_file": "",
-            "private_key_pwd": "",
-            "user": ""
-        },
+      "auth_jwt": {
+        "user": "",
+        "private_key": "",
+        "private_key_file": "",
+        "private_key_pwd": ""
+      },
         "auth_snowflake": {
             "user": "",
             "password": ""

--- a/csharp/test/Interop/Resources/snowflakeconfig.json
+++ b/csharp/test/Interop/Resources/snowflakeconfig.json
@@ -16,12 +16,12 @@
         "auth_oauth": {
             "token": ""
         },
-      "auth_jwt": {
-        "user": "",
-        "private_key": "",
-        "private_key_file": "",
-        "private_key_pwd": ""
-      },
+        "auth_jwt": {
+            "user": "",
+            "private_key": "",
+            "private_key_file": "",
+            "private_key_pwd": ""
+        },
         "auth_snowflake": {
             "user": "",
             "password": ""

--- a/csharp/test/Interop/SnowflakeTestingUtils.cs
+++ b/csharp/test/Interop/SnowflakeTestingUtils.cs
@@ -110,6 +110,21 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                 parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.Default.User, "username");
                 parameters[SnowflakeParameters.PASSWORD] = Parameter(testConfiguration.Authentication.Default.Password, "password");
             }
+            else if (testConfiguration.Authentication.SnowflakeJwt is not null)
+            {
+                parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthJwt;
+                parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.SnowflakeJwt.User, "username");
+                parameters[SnowflakeParameters.PKCS8_VALUE] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKey, "private_key");
+                if (!string.IsNullOrEmpty(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyPassPhrase))
+                {
+                    parameters[SnowflakeParameters.PKCS8_PASS] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyPassPhrase, "private_key_passphrase");
+                }
+            }
+            else if (testConfiguration.Authentication.OAuth is not null)
+            {
+                parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthOAuth;
+                parameters[SnowflakeParameters.AUTH_TOKEN] = Parameter(testConfiguration.Authentication.OAuth.Token, "oauth_token");
+            }
 
             if (!string.IsNullOrWhiteSpace(testConfiguration.Host))
             {
@@ -121,7 +136,6 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                 parameters[SnowflakeParameters.DATABASE] = testConfiguration.Database;
             }
 
-            Dictionary<string, string> options = new Dictionary<string, string>() { };
             AdbcDriver snowflakeDriver = GetSnowflakeAdbcDriver(testConfiguration);
 
             return snowflakeDriver;

--- a/csharp/test/Interop/SnowflakeTestingUtils.cs
+++ b/csharp/test/Interop/SnowflakeTestingUtils.cs
@@ -110,7 +110,10 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                 parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.Default.User, "username");
                 parameters[SnowflakeParameters.PASSWORD] = Parameter(testConfiguration.Authentication.Default.Password, "password");
             }
-            else if (testConfiguration.Authentication.SnowflakeJwt is not null)
+            else if (testConfiguration.Authentication.SnowflakeJwt is not null
+                && !string.IsNullOrWhiteSpace(testConfiguration.Authentication.SnowflakeJwt.User)
+                && (!string.IsNullOrWhiteSpace(testConfiguration.Authentication.SnowflakeJwt.PrivateKey)
+                    || !string.IsNullOrWhiteSpace(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyFile)))
             {
                 parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthJwt;
                 parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.SnowflakeJwt.User, "username");

--- a/csharp/test/Interop/SnowflakeTestingUtils.cs
+++ b/csharp/test/Interop/SnowflakeTestingUtils.cs
@@ -114,7 +114,20 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
             {
                 parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthJwt;
                 parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.SnowflakeJwt.User, "username");
-                parameters[SnowflakeParameters.PKCS8_VALUE] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKey, "private_key");
+                if (!string.IsNullOrWhiteSpace(testConfiguration.Authentication.SnowflakeJwt.PrivateKey))
+                {
+                    parameters[SnowflakeParameters.PKCS8_VALUE] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKey, "private_key");
+                }
+                else if (!string.IsNullOrWhiteSpace(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyFile)
+                    && File.Exists(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyFile))
+                {
+                    string privateKey = File.ReadAllText(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyFile);
+                    parameters[SnowflakeParameters.PKCS8_VALUE] = privateKey;
+                }
+                else
+                {
+                    throw new InvalidOperationException("JWT authentication requires either a private key value or a valid private key file path.");
+                }
                 if (!string.IsNullOrEmpty(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyPassPhrase))
                 {
                     parameters[SnowflakeParameters.PKCS8_PASS] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyPassPhrase, "private_key_passphrase");

--- a/csharp/test/Interop/SnowflakeTestingUtils.cs
+++ b/csharp/test/Interop/SnowflakeTestingUtils.cs
@@ -104,7 +104,9 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                 { SnowflakeParameters.USE_HIGH_PRECISION, testConfiguration.UseHighPrecision.ToString().ToLowerInvariant() }
             };
 
-            if (testConfiguration.Authentication.Default is not null)
+            if (testConfiguration.Authentication.Default is not null
+                && !string.IsNullOrWhiteSpace(testConfiguration.Authentication.Default.User)
+                && !string.IsNullOrWhiteSpace(testConfiguration.Authentication.Default.Password))
             {
                 parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthSnowflake;
                 parameters[SnowflakeParameters.USERNAME] = Parameter(testConfiguration.Authentication.Default.User, "username");

--- a/csharp/test/Interop/SnowflakeTestingUtils.cs
+++ b/csharp/test/Interop/SnowflakeTestingUtils.cs
@@ -136,10 +136,15 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                     parameters[SnowflakeParameters.PKCS8_PASS] = Parameter(testConfiguration.Authentication.SnowflakeJwt.PrivateKeyPassPhrase, "private_key_passphrase");
                 }
             }
-            else if (testConfiguration.Authentication.OAuth is not null)
+            else if (testConfiguration.Authentication.OAuth is not null
+                && !string.IsNullOrWhiteSpace(testConfiguration.Authentication.OAuth.Token))
             {
                 parameters[SnowflakeParameters.AUTH_TYPE] = SnowflakeAuthentication.AuthOAuth;
                 parameters[SnowflakeParameters.AUTH_TOKEN] = Parameter(testConfiguration.Authentication.OAuth.Token, "oauth_token");
+                if (!string.IsNullOrWhiteSpace(testConfiguration.Authentication.OAuth.User))
+                {
+                    parameters[SnowflakeParameters.USERNAME] = testConfiguration.Authentication.OAuth.User;
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(testConfiguration.Host))

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -1,8 +1,5 @@
 ﻿/*
-* Copyright (c) 2025 ADBC Drivers Contributors
-*
-* This file has been modified from its original version, which is
-* under the Apache License:
+* Copyright (c) 2026 ADBC Drivers Contributors
 *
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -63,6 +63,7 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                     _outputHelper?.WriteLine($"QueryResultRowCount: {queryResult.RowCount}");
                     queryResult.Stream?.Dispose();
                     Assert.Fail("Expected query to be cancelled, but it completed successfully.");
+                }
                 catch (AdbcException ex)
                 {
                     Assert.Contains("[snowflake] context canceled", ex.Message, StringComparison.OrdinalIgnoreCase);

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -61,8 +61,8 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
 
                     QueryResult queryResult = await queryTask;
                     _outputHelper?.WriteLine($"QueryResultRowCount: {queryResult.RowCount}");
-                    Assert.Fail("Expecting query to timeout, but it did not.");
-                }
+                    queryResult.Stream?.Dispose();
+                    Assert.Fail("Expected query to be cancelled, but it completed successfully.");
                 catch (AdbcException ex)
                 {
                     Assert.Contains("[snowflake] context canceled", ex.Message, StringComparison.OrdinalIgnoreCase);

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -1,0 +1,128 @@
+﻿/*
+* Copyright (c) 2025 ADBC Drivers Contributors
+*
+* This file has been modified from its original version, which is
+* under the Apache License:
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Tests;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AdbcDrivers.Snowflake.Interop.Tests
+{
+    public class StatementTests
+    {
+        readonly ITestOutputHelper _outputHelper;
+
+        public StatementTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+            Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
+        }
+
+        private static AdbcConnection CreateConnection(SnowflakeTestConfiguration testConfiguration, Dictionary<string, string>? options = null)
+        {
+            Dictionary<string, string> parameters;
+            AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+            AdbcDatabase adbcDatabase = snowflakeDriver.Open(parameters);
+            return adbcDatabase.Connect(options);
+        }
+
+        [SkippableTheory()]
+        [InlineData("SELECT SYSTEM$WAIT(30)", true)]
+        [InlineData("SELECT SYSTEM$WAIT(1)", false)]
+        internal virtual async Task CanCancelStatementTest(string query, bool testCancel)
+        {
+            const int millisecondsDelay = 500;
+
+            var snowflakeTestConfiguration = SnowflakeTestingUtils.TestConfiguration;
+
+            AdbcConnection connection = StatementTests.CreateConnection(snowflakeTestConfiguration);
+            AdbcStatement statement = connection.CreateStatement();
+            // Note: for this test to be valid, the query needs to run for more time than the delay value!
+            statement.SqlQuery = query;
+            for (int i = 0; i < 10; i++)
+            {
+                // Reuse the statement to check for issue that might arise from using the Statement multiple times.
+                try
+                {
+                    Task<QueryResult> queryTask = Task.Run(statement.ExecuteQuery);
+
+                    if (testCancel)
+                    {
+                        await Task.Delay(millisecondsDelay);
+                        statement.Cancel();
+                    }
+
+                    QueryResult queryResult = await queryTask;
+                    _outputHelper?.WriteLine($"QueryResultRowCount: {queryResult.RowCount}");
+                    if (testCancel)
+                    {
+                        Assert.Fail("Expecting query to timeout, but it did not.");
+                    }
+                }
+                catch (AdbcException ex)
+                {
+                    Assert.True(testCancel, $"Unexpected exception: {ex}");
+                    Assert.Contains("[snowflake] context canceled", ex.Message, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        private static bool ContainsException(Exception exception, Type? exceptionType, out Exception? containedException)
+        {
+            if (exceptionType == null)
+            {
+                containedException = null;
+                return false;
+            }
+
+            Exception? e = exception;
+            while (e != null)
+            {
+                if (exceptionType.IsInstanceOfType(e))
+                {
+                    containedException = e;
+                    return true;
+                }
+                else if (e is AggregateException aggregateException)
+                {
+                    foreach (Exception? ex in aggregateException.InnerExceptions)
+                    {
+                        if (ContainsException(ex, exceptionType, out Exception? inner))
+                        {
+                            containedException = inner;
+                            return true;
+                        }
+                    }
+                }
+                e = e.InnerException;
+            }
+
+            containedException = null;
+            return false;
+        }
+
+    }
+}

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -89,40 +89,5 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
                 }
             }
         }
-
-        private static bool ContainsException(Exception exception, Type? exceptionType, out Exception? containedException)
-        {
-            if (exceptionType == null)
-            {
-                containedException = null;
-                return false;
-            }
-
-            Exception? e = exception;
-            while (e != null)
-            {
-                if (exceptionType.IsInstanceOfType(e))
-                {
-                    containedException = e;
-                    return true;
-                }
-                else if (e is AggregateException aggregateException)
-                {
-                    foreach (Exception? ex in aggregateException.InnerExceptions)
-                    {
-                        if (ContainsException(ex, exceptionType, out Exception? inner))
-                        {
-                            containedException = inner;
-                            return true;
-                        }
-                    }
-                }
-                e = e.InnerException;
-            }
-
-            containedException = null;
-            return false;
-        }
-
     }
 }

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -34,52 +34,37 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
             Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
         }
 
-        private static AdbcConnection CreateConnection(SnowflakeTestConfiguration testConfiguration, Dictionary<string, string>? options = null)
+        [SkippableFact]
+        public async Task CanCancelStatementTest()
         {
-            Dictionary<string, string> parameters;
-            AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
-            AdbcDatabase adbcDatabase = snowflakeDriver.Open(parameters);
-            return adbcDatabase.Connect(options);
-        }
-
-        [SkippableTheory]
-        [InlineData("SELECT SYSTEM$WAIT(30)", true)]
-        [InlineData("SELECT SYSTEM$WAIT(1)", false)]
-        public async Task CanCancelStatementTest(string query, bool testCancel)
             const int millisecondsDelay = 500;
+            const string query = "SELECT SYSTEM$WAIT(30)";
 
             var snowflakeTestConfiguration = SnowflakeTestingUtils.TestConfiguration;
 
-            Dictionary<string, string> parameters;
-            using AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(snowflakeTestConfiguration, out parameters);
+            using AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(snowflakeTestConfiguration, out Dictionary<string, string> parameters);
             using AdbcDatabase adbcDatabase = snowflakeDriver.Open(parameters);
             using AdbcConnection connection = adbcDatabase.Connect(new Dictionary<string, string>());
             using AdbcStatement statement = connection.CreateStatement();
+
             // Note: for this test to be valid, the query needs to run for more time than the delay value!
             statement.SqlQuery = query;
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 5; i++)
             {
                 // Reuse the statement to check for issue that might arise from using the Statement multiple times.
                 try
                 {
                     Task<QueryResult> queryTask = Task.Run(statement.ExecuteQuery);
 
-                    if (testCancel)
-                    {
-                        await Task.Delay(millisecondsDelay);
-                        statement.Cancel();
-                    }
+                    await Task.Delay(millisecondsDelay);
+                    statement.Cancel();
 
                     QueryResult queryResult = await queryTask;
                     _outputHelper?.WriteLine($"QueryResultRowCount: {queryResult.RowCount}");
-                    if (testCancel)
-                    {
-                        Assert.Fail("Expecting query to timeout, but it did not.");
-                    }
+                    Assert.Fail("Expecting query to timeout, but it did not.");
                 }
                 catch (AdbcException ex)
                 {
-                    Assert.True(testCancel, $"Unexpected exception: {ex}");
                     Assert.Contains("[snowflake] context canceled", ex.Message, StringComparison.OrdinalIgnoreCase);
                 }
             }

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -1,15 +1,11 @@
 ﻿/*
 * Copyright (c) 2026 ADBC Drivers Contributors
 *
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -50,8 +50,11 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
 
             var snowflakeTestConfiguration = SnowflakeTestingUtils.TestConfiguration;
 
-            AdbcConnection connection = StatementTests.CreateConnection(snowflakeTestConfiguration);
-            AdbcStatement statement = connection.CreateStatement();
+            Dictionary<string, string> parameters;
+            using AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(snowflakeTestConfiguration, out parameters);
+            using AdbcDatabase adbcDatabase = snowflakeDriver.Open(parameters);
+            using AdbcConnection connection = adbcDatabase.Connect(new Dictionary<string, string>());
+            using AdbcStatement statement = connection.CreateStatement();
             // Note: for this test to be valid, the query needs to run for more time than the delay value!
             statement.SqlQuery = query;
             for (int i = 0; i < 10; i++)

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -42,11 +42,10 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
             return adbcDatabase.Connect(options);
         }
 
-        [SkippableTheory()]
+        [SkippableTheory]
         [InlineData("SELECT SYSTEM$WAIT(30)", true)]
         [InlineData("SELECT SYSTEM$WAIT(1)", false)]
-        internal virtual async Task CanCancelStatementTest(string query, bool testCancel)
-        {
+        public async Task CanCancelStatementTest(string query, bool testCancel)
             const int millisecondsDelay = 500;
 
             var snowflakeTestConfiguration = SnowflakeTestingUtils.TestConfiguration;

--- a/csharp/test/Interop/StatementTests.cs
+++ b/csharp/test/Interop/StatementTests.cs
@@ -38,8 +38,7 @@ namespace AdbcDrivers.Snowflake.Interop.Tests
         public async Task CanCancelStatementTest()
         {
             const int millisecondsDelay = 500;
-            const string query = "SELECT SYSTEM$WAIT(30)";
-
+            const string query = "SELECT SYSTEM$WAIT(5)";
             var snowflakeTestConfiguration = SnowflakeTestingUtils.TestConfiguration;
 
             using AdbcDriver snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(snowflakeTestConfiguration, out Dictionary<string, string> parameters);


### PR DESCRIPTION
## What's Changed

- Added a test for Statement.Cancel
- Adds support for key-pair and Oauth authentication in the test configuration file.
- Updates Microsoft.NET.Test.Sdk reference to version 18.5.1
- Corrects indentation in the project file.
- Commit submodule reference to `arrow-adbc` has been updated to latest.
