### PR TITLE
feat(go): support binding Float16 parameters

### DIFF
--- a/go/binding.go
+++ b/go/binding.go
@@ -68,6 +68,12 @@ func convertArrowToNamedValue(batch arrow.RecordBatch, index int, params []drive
 				Bool:  column.Value(index),
 				Valid: column.IsValid(index),
 			}
+		case *array.Float16:
+			// Snowflake only recognizes float64
+			params[i].Value = sql.NullFloat64{
+				Float64: float64(column.Value(index).Float32()),
+				Valid:   column.IsValid(index),
+			}
 		case *array.Float32:
 			// Snowflake only recognizes float64
 			params[i].Value = sql.NullFloat64{

--- a/go/binding_test.go
+++ b/go/binding_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
+	"github.com/apache/arrow-go/v18/arrow/float16"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -322,6 +323,55 @@ func TestConvertDecimal256(t *testing.T) {
 	ns := params[0].Value.(sql.NullString)
 	assert.True(t, ns.Valid)
 	assert.Equal(t, "123.456", ns.String)
+}
+
+func TestConvertFloat16(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "f16", Type: arrow.FixedWidthTypes.Float16, Nullable: true},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, sc)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Float16Builder).Append(float16.New(1.5))
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	params, err := convertArrowToNamedValue(rec, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, params, 1)
+
+	nf := params[0].Value.(sql.NullFloat64)
+	assert.True(t, nf.Valid)
+	assert.Equal(t, 1.5, nf.Float64)
+	assert.Equal(t, 1, params[0].Ordinal)
+}
+
+func TestConvertFloat16Null(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "f16", Type: arrow.FixedWidthTypes.Float16, Nullable: true},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(mem, sc)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Float16Builder).AppendNull()
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	params, err := convertArrowToNamedValue(rec, 0, nil)
+	require.NoError(t, err)
+
+	nf := params[0].Value.(sql.NullFloat64)
+	assert.False(t, nf.Valid)
 }
 
 func TestConvertMixedTypes(t *testing.T) {

--- a/go/validation/queries/type/bind/float16.txtcase
+++ b/go/validation/queries/type/bind/float16.txtcase
@@ -13,4 +13,73 @@
 // limitations under the License.
 
 // part: metadata
-skip = "float16 parameter binding not supported by Snowflake driver"
+
+[setup]
+drop = "test_float16"
+
+[tags]
+sql-type-name = "REAL"
+
+// part: setup_query
+
+CREATE TABLE "test_float16" (
+    "idx" INT,
+    "res" REAL
+);
+
+// part: bind_query
+
+INSERT INTO "test_float16" VALUES ($1, $2)
+
+// part: bind_schema
+
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "i",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "res",
+            "format": "e",
+            "flags": ["nullable"]
+        }
+    ]
+}
+
+// part: bind
+
+{"idx": 0, "res": null}
+{"idx": 1, "res": 0.0}
+{"idx": 2, "res": 1.5}
+{"idx": 3, "res": -2.5}
+{"idx": 4, "res": 65504}
+{"idx": 5, "res": -65504}
+
+// part: query
+
+SELECT "res" FROM "test_float16" ORDER BY "idx"
+
+// part: expected_schema
+
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "res",
+            "format": "g",
+            "flags": ["nullable"]
+        }
+    ]
+}
+
+// part: expected
+
+{"res": null}
+{"res": 0.0}
+{"res": 1.5}
+{"res": -2.5}
+{"res": 65504.0}
+{"res": -65504.0}


### PR DESCRIPTION
## What's Changed

Two small changes from triaging the open issues:

- **feat(go): bind Float16 parameters** — `convertArrowToNamedValue` now handles
  `array.Float16`, converting to `float64` (the only floating-point type Snowflake
  binds for parameters), mirroring the existing `Float32` path. Adds unit tests for
  valid and null values. This was the last remaining type from #47; binary, temporal,
  and decimal binding were added earlier in #108.
- **docs: `adbc.rpc.result_queue_size`** — document its relationship to
  `adbc.snowflake.rpc.prefetch_concurrency` and add a copy-paste example showing how
  to set the option on a statement, per apache/arrow-adbc#2328. The two
  `ingest_compression_*` options remain undocumented until they are implemented (#124).

### Verification

- `gofmt -l` clean, `go vet ./...` clean
- `go test -run TestConvert` passes (includes the new `TestConvertFloat16` /
  `TestConvertFloat16Null`)
- `pre-commit run` passes (golangci-lint, codespell, Apache RAT, gofix)

Closes #47.

Addresses #125 and apache/arrow-adbc#2328.
