### PR TITLE
feat(go): add bulk ingestion compression codec and level options

### DIFF
--- a/go/docs/snowflake.md
+++ b/go/docs/snowflake.md
@@ -272,6 +272,20 @@ Examples:
 
   Can be set on the database, connection, and statement.
 
+`adbc.snowflake.statement.ingest_compression_codec`
+: **Values:** `uncompressed`, `snappy`, `gzip`, `brotli`, `zstd`, or `lz4_raw` (case-insensitive). **Default:** `snappy`
+
+  When ingesting, the compression codec to use for the Parquet files that are created and uploaded.
+
+  Can be set on the statement.
+
+`adbc.snowflake.statement.ingest_compression_level`
+: **Type:** int. **Default:** the default level for the selected codec
+
+  When ingesting, the codec-specific compression level for the Parquet files that are created. The valid range depends on the codec; some codecs (such as `snappy`) ignore it.
+
+  Can be set on the statement.
+
 `adbc.snowflake.statement.ingest_copy_concurrency`
 : **Type:** int. **Default:** 4
 

--- a/go/statement.go
+++ b/go/statement.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet/compress"
 	"github.com/snowflakedb/gosnowflake/v2"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
@@ -49,8 +50,8 @@ const (
 	OptionStatementIngestUploadConcurrency = "adbc.snowflake.statement.ingest_upload_concurrency"
 	OptionStatementIngestCopyConcurrency   = "adbc.snowflake.statement.ingest_copy_concurrency"
 	OptionStatementIngestTargetFileSize    = "adbc.snowflake.statement.ingest_target_file_size"
-	OptionStatementIngestCompressionCodec  = "adbc.snowflake.statement.ingest_compression_codec" // TODO(GH-1473): Implement option
-	OptionStatementIngestCompressionLevel  = "adbc.snowflake.statement.ingest_compression_level" // TODO(GH-1473): Implement option
+	OptionStatementIngestCompressionCodec  = "adbc.snowflake.statement.ingest_compression_codec"
+	OptionStatementIngestCompressionLevel  = "adbc.snowflake.statement.ingest_compression_level"
 	OptionStatementVectorizedScanner       = "adbc.snowflake.statement.ingest_use_vectorized_scanner"
 	// OptionStatementIngestGeoType controls the Snowflake type created for
 	// columns with geoarrow extension types (geoarrow.wkb, geoarrow.wkt).
@@ -170,6 +171,27 @@ func (st *statement) GetOptionDouble(ctx context.Context, key string) (float64, 
 	}
 }
 
+// parseCompressionCodec resolves a codec name (case-insensitive) via Arrow's
+// canonical names. The GetCodec call rejects codecs Arrow knows by name but has
+// no registered implementation for (e.g. lzo, plain lz4), which would otherwise
+// fail only later at write time.
+func parseCompressionCodec(val string) (compress.Compression, error) {
+	var codec compress.Compression
+	if err := codec.UnmarshalText([]byte(strings.ToUpper(strings.TrimSpace(val)))); err != nil {
+		return 0, adbc.Error{
+			Msg:  fmt.Sprintf("[Snowflake] invalid compression codec '%s': must be one of uncompressed, snappy, gzip, brotli, zstd, lz4_raw", val),
+			Code: adbc.StatusInvalidArgument,
+		}
+	}
+	if _, err := compress.GetCodec(codec); err != nil {
+		return 0, adbc.Error{
+			Msg:  fmt.Sprintf("[Snowflake] unsupported compression codec '%s': %s", val, err.Error()),
+			Code: adbc.StatusInvalidArgument,
+		}
+	}
+	return codec, nil
+}
+
 // SetOption sets a string option on this statement
 func (st *statement) SetOption(ctx context.Context, key string, val string) error {
 	switch key {
@@ -250,6 +272,22 @@ func (st *statement) SetOption(ctx context.Context, key string, val string) erro
 			}
 		}
 		return st.SetOptionInt(ctx, key, int64(size))
+	case OptionStatementIngestCompressionCodec:
+		codec, err := parseCompressionCodec(val)
+		if err != nil {
+			return err
+		}
+		st.ingestOptions.compressionCodec = codec
+		return nil
+	case OptionStatementIngestCompressionLevel:
+		level, err := strconv.Atoi(val)
+		if err != nil {
+			return adbc.Error{
+				Msg:  fmt.Sprintf("[Snowflake] could not parse '%s' as int for option '%s'", val, key),
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
+		return st.SetOptionInt(ctx, key, int64(level))
 	case OptionStatementQueryTag:
 		st.queryTag = val
 		return nil
@@ -377,6 +415,9 @@ func (st *statement) SetOptionInt(ctx context.Context, key string, value int64) 
 			}
 		}
 		st.ingestOptions.targetFileSize = uint(value)
+		return nil
+	case OptionStatementIngestCompressionLevel:
+		st.ingestOptions.compressionLevel = int(value)
 		return nil
 	}
 	return adbc.Error{

--- a/go/statement_test.go
+++ b/go/statement_test.go
@@ -15,12 +15,16 @@
 package snowflake
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/parquet/compress"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // geoArrowType implements arrow.ExtensionType for testing geoarrow types
@@ -251,4 +255,67 @@ func TestResolveGeoType(t *testing.T) {
 	ty, err = opts.resolveGeoType(0, "geom", `{"crs":"EPSG:3857", "edges":"spherical"}`)
 	assert.NoError(t, err)
 	assert.Equal(t, "geography", ty)
+}
+
+func TestSetOptionCompressionCodec(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      string
+		expected compress.Compression
+	}{
+		{"snappy lower", "snappy", compress.Codecs.Snappy},
+		{"snappy upper", "SNAPPY", compress.Codecs.Snappy},
+		{"gzip", "gzip", compress.Codecs.Gzip},
+		{"zstd", "zstd", compress.Codecs.Zstd},
+		{"brotli", "brotli", compress.Codecs.Brotli},
+		{"lz4_raw", "lz4_raw", compress.Codecs.Lz4Raw},
+		{"uncompressed", "uncompressed", compress.Codecs.Uncompressed},
+		{"mixed case and spaces", "  ZsTd  ", compress.Codecs.Zstd},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &statement{ingestOptions: DefaultIngestOptions()}
+			require.NoError(t, st.SetOption(context.Background(), OptionStatementIngestCompressionCodec, tt.val))
+			assert.Equal(t, tt.expected, st.ingestOptions.compressionCodec)
+		})
+	}
+}
+
+func TestSetOptionCompressionCodecInvalid(t *testing.T) {
+	for _, val := range []string{"lzo", "lz4", "garbage", ""} {
+		t.Run("invalid_"+val, func(t *testing.T) {
+			st := &statement{ingestOptions: DefaultIngestOptions()}
+			err := st.SetOption(context.Background(), OptionStatementIngestCompressionCodec, val)
+			require.Error(t, err)
+			var adbcErr adbc.Error
+			require.ErrorAs(t, err, &adbcErr)
+			assert.Equal(t, adbc.StatusInvalidArgument, adbcErr.Code)
+		})
+	}
+}
+
+func TestSetOptionCompressionLevel(t *testing.T) {
+	t.Run("via SetOption", func(t *testing.T) {
+		st := &statement{ingestOptions: DefaultIngestOptions()}
+		require.NoError(t, st.SetOption(context.Background(), OptionStatementIngestCompressionLevel, "6"))
+		assert.Equal(t, 6, st.ingestOptions.compressionLevel)
+	})
+	t.Run("via SetOptionInt", func(t *testing.T) {
+		st := &statement{ingestOptions: DefaultIngestOptions()}
+		require.NoError(t, st.SetOptionInt(context.Background(), OptionStatementIngestCompressionLevel, 9))
+		assert.Equal(t, 9, st.ingestOptions.compressionLevel)
+	})
+	t.Run("negative level accepted", func(t *testing.T) {
+		st := &statement{ingestOptions: DefaultIngestOptions()}
+		require.NoError(t, st.SetOptionInt(context.Background(), OptionStatementIngestCompressionLevel, -1))
+		assert.Equal(t, -1, st.ingestOptions.compressionLevel)
+	})
+	t.Run("non-integer rejected", func(t *testing.T) {
+		st := &statement{ingestOptions: DefaultIngestOptions()}
+		err := st.SetOption(context.Background(), OptionStatementIngestCompressionLevel, "notanint")
+		require.Error(t, err)
+		var adbcErr adbc.Error
+		require.ErrorAs(t, err, &adbcErr)
+		assert.Equal(t, adbc.StatusInvalidArgument, adbcErr.Code)
+	})
 }


### PR DESCRIPTION
## Summary

Implements the bulk-ingestion compression options that were previously stubbed
as constants with `TODO(GH-1473)` markers, wiring them through `SetOption` /
`SetOptionInt` to the existing `ingestOptions` infrastructure.

- `adbc.snowflake.statement.ingest_compression_codec`: accepts `uncompressed`,
  `snappy` (default), `gzip`, `brotli`, `zstd`, and `lz4_raw` (case-insensitive).
  Parsed via Arrow's `compress.Compression.UnmarshalText` and validated with
  `compress.GetCodec`, so codecs recognized by name but with no registered
  implementation (e.g. lzo, plain lz4) are rejected with `StatusInvalidArgument`.
- `adbc.snowflake.statement.ingest_compression_level`: integer; `SetOption`
  delegates to `SetOptionInt`; stored verbatim (range is codec-specific; `-1`
  selects the codec default).
- Removes the `TODO(GH-1473)` markers and documents both options in
  `go/docs/snowflake.md`.

The codec/level values were already applied to the Parquet writer via
`parquet.WithCompression` / `WithCompressionLevel`; only the option parsing was
missing.

## Testing

From `go/`: `go build ./...`, `go vet ./...`, and `go test -tags assert ./...`
all pass. New unit tests cover codec parsing (case-insensitive plus invalid
rejection) and level parsing via both `SetOption` and `SetOptionInt`.
Integration tests skip without `SNOWFLAKE_URI`.

Closes #124
