### PR TITLE
fix(go): set xdbc_column_size for BINARY columns in GetObjects

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -191,7 +191,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 
 	var (
 		pkQueryID, fkQueryID, uniqueQueryID, terseDbQueryID string
-		showSchemaQueryID, tableQueryID                     string
+		showSchemaQueryID, tableQueryID, columnsQueryID     string
 	)
 
 	conn := c.cn
@@ -287,6 +287,11 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 			return err
 		})
 
+		gQueryIDs.Go(func() (err error) {
+			columnsQueryID, err = getQueryID(gQueryIDsCtx, "SHOW COLUMNS /* ADBC:getObjects */"+suffix, conn, "SHOW COLUMNS /* ADBC:getObjects */ LIKE '' IN ACCOUNT")
+			return err
+		})
+
 		goGetQueryID(gQueryIDsCtx, conn, gQueryIDs, objDatabases,
 			catalog, dbSchema, tableName, &terseDbQueryID)
 		goGetQueryID(gQueryIDsCtx, conn, gQueryIDs, objSchemas,
@@ -324,6 +329,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 		sql.Named("SHOW_DB_QUERY_ID", terseDbQueryID),
 		sql.Named("SHOW_SCHEMA_QUERY_ID", showSchemaQueryID),
 		sql.Named("SHOW_TABLE_QUERY_ID", tableQueryID),
+		sql.Named("SHOW_COLUMNS_QUERY_ID", columnsQueryID),
 	}
 
 	nvargs := make([]driver.NamedValue, len(args))

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1666,6 +1666,82 @@ func (suite *SnowflakeTests) TestMetadataGetObjectsColumnsXdbc() {
 
 }
 
+func (suite *SnowflakeTests) TestMetadataGetObjectsColumnsBinaryXdbc() {
+	suite.Require().NoError(suite.Quirks.DropTable(suite.cnxn, "binary_columns"))
+
+	db := sql.OpenDB(suite.Quirks.connector)
+	defer testutil.CheckedClose(suite.T(), db)
+
+	_, err := db.ExecContext(suite.ctx, `CREATE TABLE "binary_columns" (COL_BINARY BINARY, COL_BINARY_N BINARY(10))`)
+	suite.Require().NoError(err)
+	defer func() {
+		_ = suite.Quirks.DropTable(suite.cnxn, "binary_columns")
+	}()
+
+	var (
+		expectedColnames  = []string{"col_binary", "col_binary_n"}
+		expectedTypeNames = []string{"BINARY", "BINARY"}
+		expectedColSizes  = []string{"8388608", "10"}
+	)
+
+	catalog := suite.Quirks.Catalog()
+	schema := suite.Quirks.DBSchema()
+	filterTable := "binary_columns"
+
+	rdr, err := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthColumns, &catalog, &schema, &filterTable, nil, nil)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	var (
+		foundExpected = false
+		colnames      = make([]string, 0)
+		typeNames     = make([]string, 0)
+		colSizes      = make([]string, 0)
+	)
+
+	for rdr.Next() {
+		rec := rdr.RecordBatch()
+		catalogDbSchemasList := rec.Column(1).(*array.List)
+		catalogDbSchemas := catalogDbSchemasList.ListValues().(*array.Struct)
+		dbSchemaNames := catalogDbSchemas.Field(0).(*array.String)
+		dbSchemaTablesList := catalogDbSchemas.Field(1).(*array.List)
+		dbSchemaTables := dbSchemaTablesList.ListValues().(*array.Struct)
+		tableColumnsList := dbSchemaTables.Field(2).(*array.List)
+		tableColumns := tableColumnsList.ListValues().(*array.Struct)
+
+		for row := range rec.NumRows() {
+			dbSchemaIdxStart, dbSchemaIdxEnd := catalogDbSchemasList.ValueOffsets(int(row))
+			for dbSchemaIdx := dbSchemaIdxStart; dbSchemaIdx < dbSchemaIdxEnd; dbSchemaIdx++ {
+				schemaName := dbSchemaNames.Value(int(dbSchemaIdx))
+				tblIdxStart, tblIdxEnd := dbSchemaTablesList.ValueOffsets(int(dbSchemaIdx))
+				for tblIdx := tblIdxStart; tblIdx < tblIdxEnd; tblIdx++ {
+					tableName := dbSchemaTables.Field(0).(*array.String).Value(int(tblIdx))
+					if strings.EqualFold(schemaName, suite.Quirks.DBSchema()) && strings.EqualFold("binary_columns", tableName) {
+						foundExpected = true
+
+						colIdxStart, colIdxEnd := tableColumnsList.ValueOffsets(int(tblIdx))
+						for colIdx := colIdxStart; colIdx < colIdxEnd; colIdx++ {
+							name := tableColumns.Field(0).(*array.String).Value(int(colIdx))
+							colnames = append(colnames, strings.ToLower(name))
+
+							typeNames = append(typeNames, tableColumns.Field(4).(*array.String).Value(int(colIdx)))
+
+							colSize := tableColumns.Field(5).(*array.Int32).Value(int(colIdx))
+							colSizes = append(colSizes, strconv.Itoa(int(colSize)))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	suite.NoError(rdr.Err())
+	suite.True(foundExpected)
+	suite.ElementsMatch(expectedColnames, colnames)
+	suite.ElementsMatch(expectedTypeNames, typeNames)
+	suite.ElementsMatch(expectedColSizes, colSizes)
+}
+
 func (suite *SnowflakeTests) TestNewDatabaseGetSetOptions() {
 	key1, val1 := "key1", "val1"
 	key2, val2 := "key2", "val2"

--- a/go/queries/get_objects_all.sql
+++ b/go/queries/get_objects_all.sql
@@ -20,27 +20,42 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-WITH columns AS (
+WITH show_columns AS (
     SELECT
-        table_catalog,
-        table_schema,
-        table_name,
+        "database_name" table_catalog,
+        "schema_name" table_schema,
+        "table_name" table_name,
+        "column_name" column_name,
+        TRY_PARSE_JSON("data_type"):"byteLength"::int AS byte_length
+    FROM TABLE(RESULT_SCAN(:SHOW_COLUMNS_QUERY_ID))
+    WHERE "database_name" ILIKE :CATALOG AND "schema_name" ILIKE :DB_SCHEMA AND "table_name" ILIKE :TABLE AND "column_name" ILIKE :COLUMN
+),
+columns AS (
+    SELECT
+        c.table_catalog,
+        c.table_schema,
+        c.table_name,
         ARRAY_AGG({
-        	'column_name': column_name,
+        	'column_name': c.column_name,
         	'ordinal_position': ordinal_position,
         	'remarks': comment,
         	'xdbc_type_name': data_type,
         	'xdbc_is_nullable': is_nullable,
         	'xdbc_nullable': is_nullable::boolean::int,
-        	'xdbc_column_size': coalesce(character_maximum_length, numeric_precision),
+        	'xdbc_column_size': coalesce(character_maximum_length, numeric_precision, IFF(data_type = 'BINARY', sc.byte_length, NULL)),
         	'xdbc_char_octet_length': character_octet_length,
         	'xdbc_decimal_digits': numeric_scale,
         	'xdbc_num_prec_radix': numeric_precision_radix,
         	'xdbc_datetime_sub': datetime_precision
         }) WITHIN GROUP (ORDER BY ordinal_position) table_columns,
-    FROM information_schema.columns
-    WHERE table_catalog ILIKE :CATALOG AND table_schema ILIKE :DB_SCHEMA AND table_name ILIKE :TABLE AND column_name ILIKE :COLUMN
-    GROUP BY table_catalog, table_schema, table_name
+    FROM information_schema.columns c
+    LEFT JOIN show_columns sc
+      ON c.table_catalog = sc.table_catalog
+     AND c.table_schema = sc.table_schema
+     AND c.table_name = sc.table_name
+     AND c.column_name = sc.column_name
+    WHERE c.table_catalog ILIKE :CATALOG AND c.table_schema ILIKE :DB_SCHEMA AND c.table_name ILIKE :TABLE AND c.column_name ILIKE :COLUMN
+    GROUP BY c.table_catalog, c.table_schema, c.table_name
 ),
 pk_constraints AS (
     SELECT


### PR DESCRIPTION
## Summary

`GetObjects(..., ObjectDepthColumns, ...)` returned a NULL `xdbc_column_size`
for `BINARY` columns. Snowflake's `INFORMATION_SCHEMA.COLUMNS` populates neither
`CHARACTER_MAXIMUM_LENGTH` nor `NUMERIC_PRECISION` for `BINARY`, so the existing
`coalesce(character_maximum_length, numeric_precision)` was NULL. The byte
length is available from `SHOW COLUMNS` (its `data_type` JSON has a `byteLength`
field).

- `go/connection.go`: in the columns/all path, fire `SHOW COLUMNS` (scoped by
  the same suffix used for the `SHOW ... KEYS` queries), capture its query id,
  and bind it as `:SHOW_COLUMNS_QUERY_ID`. A `LIKE '' IN ACCOUNT` empty-query
  fallback handles the case where the scope matches nothing (error 2043).
- `go/queries/get_objects_all.sql`: add a `show_columns` CTE over
  `RESULT_SCAN(:SHOW_COLUMNS_QUERY_ID)` that extracts
  `TRY_PARSE_JSON("data_type"):"byteLength"`, LEFT JOIN it into the `columns`
  CTE, and use it as a BINARY-only third argument of the `xdbc_column_size`
  coalesce. TEXT and NUMBER sizes are unchanged.
- `go/driver_test.go`: add `TestMetadataGetObjectsColumnsBinaryXdbc`, which
  creates `BINARY` and `BINARY(10)` columns and asserts `xdbc_column_size` of
  8388608 and 10 respectively.

## Caveats

- One extra `SHOW COLUMNS` round-trip per `GetObjects` call at columns/all depth.
- `SHOW COLUMNS` is capped at 10,000 rows; for very wide account- or
  database-wide scopes, byte lengths beyond that cap are unavailable (column
  size stays NULL, i.e. the prior behavior).

## Testing

From `go/`: `go build ./...`, `go vet ./...`, and golangci-lint (via pre-commit)
pass. The new integration test requires a live Snowflake instance and is skipped
without `SNOWFLAKE_URI`/`SNOWFLAKE_DATABASE`; existing expectations (NUMBER=38,
TEXT=16777216) are unchanged.

Closes #127
