### PR TITLE
test(go): enable GetObjects constraint validation tests

### DIFF
--- a/go/validation/tests/snowflake.py
+++ b/go/validation/tests/snowflake.py
@@ -66,22 +66,24 @@ class SnowflakeQuirks(model.DriverQuirks):
 
     @property
     def sample_ddl_constraints(self) -> list[str]:
-        # The leading "z" column is dropped after creation so constraint columns
-        # are not at ordinal position 1, ensuring GetObjects maps them by name
-        # rather than by ordinal position.
+        # Identifiers are quoted to preserve lower case: Snowflake folds unquoted
+        # names to upper case, but the validation suite matches the names exactly
+        # as written. The leading "z" column is dropped after creation so the
+        # constraint columns are not at ordinal position 1, ensuring GetObjects
+        # maps them by name rather than by ordinal position.
         return [
-            "CREATE TABLE constraint_primary (z INT, a INT, b STRING, PRIMARY KEY (a))",
-            "CREATE TABLE constraint_primary_multi (z INT, a INT, b STRING, PRIMARY KEY (b, a))",
-            "CREATE TABLE constraint_primary_multi2 (z INT, a STRING, b INT, PRIMARY KEY (a, b))",
-            "CREATE TABLE constraint_unique (z INT, a INT, b INT, c INT, UNIQUE (a), UNIQUE (c, b))",
-            "CREATE TABLE constraint_foreign (z INT, a INT, b INT, FOREIGN KEY (b) REFERENCES constraint_primary (a))",
-            "CREATE TABLE constraint_foreign_multi (z INT, a INT, b INT, c STRING, FOREIGN KEY (c, b) REFERENCES constraint_primary_multi2 (a, b))",
-            "ALTER TABLE constraint_primary DROP COLUMN z",
-            "ALTER TABLE constraint_primary_multi DROP COLUMN z",
-            "ALTER TABLE constraint_primary_multi2 DROP COLUMN z",
-            "ALTER TABLE constraint_unique DROP COLUMN z",
-            "ALTER TABLE constraint_foreign DROP COLUMN z",
-            "ALTER TABLE constraint_foreign_multi DROP COLUMN z",
+            'CREATE TABLE "constraint_primary" ("z" INT, "a" INT, "b" STRING, PRIMARY KEY ("a"))',
+            'CREATE TABLE "constraint_primary_multi" ("z" INT, "a" INT, "b" STRING, PRIMARY KEY ("b", "a"))',
+            'CREATE TABLE "constraint_primary_multi2" ("z" INT, "a" STRING, "b" INT, PRIMARY KEY ("a", "b"))',
+            'CREATE TABLE "constraint_unique" ("z" INT, "a" INT, "b" INT, "c" INT, UNIQUE ("a"), UNIQUE ("c", "b"))',
+            'CREATE TABLE "constraint_foreign" ("z" INT, "a" INT, "b" INT, FOREIGN KEY ("b") REFERENCES "constraint_primary" ("a"))',
+            'CREATE TABLE "constraint_foreign_multi" ("z" INT, "a" INT, "b" INT, "c" STRING, FOREIGN KEY ("c", "b") REFERENCES "constraint_primary_multi2" ("a", "b"))',
+            'ALTER TABLE "constraint_primary" DROP COLUMN "z"',
+            'ALTER TABLE "constraint_primary_multi" DROP COLUMN "z"',
+            'ALTER TABLE "constraint_primary_multi2" DROP COLUMN "z"',
+            'ALTER TABLE "constraint_unique" DROP COLUMN "z"',
+            'ALTER TABLE "constraint_foreign" DROP COLUMN "z"',
+            'ALTER TABLE "constraint_foreign_multi" DROP COLUMN "z"',
         ]
 
     def is_table_not_found(self, table_name: str | None, error: Exception) -> bool:

--- a/go/validation/tests/snowflake.py
+++ b/go/validation/tests/snowflake.py
@@ -30,9 +30,9 @@ class SnowflakeQuirks(model.DriverQuirks):
         connection_get_table_schema=True,
         connection_transactions=True,
         get_objects=True,
-        get_objects_constraints_foreign=False,
-        get_objects_constraints_primary=False,
-        get_objects_constraints_unique=False,
+        get_objects_constraints_foreign=True,
+        get_objects_constraints_primary=True,
+        get_objects_constraints_unique=True,
         statement_bind=True,
         statement_bulk_ingest=True,
         statement_bulk_ingest_catalog=True,
@@ -63,6 +63,26 @@ class SnowflakeQuirks(model.DriverQuirks):
     @property
     def queries_paths(self) -> tuple[Path]:
         return (Path(__file__).parent.parent / "queries",)
+
+    @property
+    def sample_ddl_constraints(self) -> list[str]:
+        # The leading "z" column is dropped after creation so constraint columns
+        # are not at ordinal position 1, ensuring GetObjects maps them by name
+        # rather than by ordinal position.
+        return [
+            "CREATE TABLE constraint_primary (z INT, a INT, b STRING, PRIMARY KEY (a))",
+            "CREATE TABLE constraint_primary_multi (z INT, a INT, b STRING, PRIMARY KEY (b, a))",
+            "CREATE TABLE constraint_primary_multi2 (z INT, a STRING, b INT, PRIMARY KEY (a, b))",
+            "CREATE TABLE constraint_unique (z INT, a INT, b INT, c INT, UNIQUE (a), UNIQUE (c, b))",
+            "CREATE TABLE constraint_foreign (z INT, a INT, b INT, FOREIGN KEY (b) REFERENCES constraint_primary (a))",
+            "CREATE TABLE constraint_foreign_multi (z INT, a INT, b INT, c STRING, FOREIGN KEY (c, b) REFERENCES constraint_primary_multi2 (a, b))",
+            "ALTER TABLE constraint_primary DROP COLUMN z",
+            "ALTER TABLE constraint_primary_multi DROP COLUMN z",
+            "ALTER TABLE constraint_primary_multi2 DROP COLUMN z",
+            "ALTER TABLE constraint_unique DROP COLUMN z",
+            "ALTER TABLE constraint_foreign DROP COLUMN z",
+            "ALTER TABLE constraint_foreign_multi DROP COLUMN z",
+        ]
 
     def is_table_not_found(self, table_name: str | None, error: Exception) -> bool:
         error_msg = str(error).lower()


### PR DESCRIPTION
## What's Changed

Enables the `primary`, `foreign`, and `unique` GetObjects constraint validation tests for the Snowflake driver.

### Background

The constraint metadata implementation already exists in the SQL-template path of `GetObjects`: `connection.go` dispatches `SHOW PRIMARY KEYS` / `SHOW IMPORTED KEYS` / `SHOW UNIQUE KEYS`, and `queries/get_objects_all.sql` assembles the `table_constraints` structure. The three validation tests (`test_get_objects_constraints_{primary,foreign,unique}`) errored with `NotImplementedError` only because the Snowflake quirks class did not define the required `sample_ddl_constraints` property.

### Changes (`go/validation/tests/snowflake.py`)

- Add `sample_ddl_constraints` with Snowflake DDL that creates the primary / unique / foreign constraint fixture tables (modeled on the BigQuery driver's fixtures, adapted to Snowflake syntax — no `NOT ENFORCED` clause, plus a `constraint_unique` table since Snowflake supports `UNIQUE`).
- Enable `get_objects_constraints_foreign`, `get_objects_constraints_primary`, and `get_objects_constraints_unique`.

All identifiers in the DDL are quoted to preserve lower case: Snowflake folds unquoted identifiers to upper case, but the validation suite matches table/column names exactly as written (lower case), consistent with how the suite's `adbc_ingest` fixtures round-trip.

`get_objects_constraints_check` stays disabled (Snowflake does not support CHECK constraints). The `_normalized` quirks stay `False` because Snowflake preserves the declared key column order (`key_sequence`), matching the non-normalized branch of the tests.

### Note on `constraint_column_usage`

No driver/SQL change is required. The query emits `[]` for primary/unique constraint usage, and the driverbase build round-trip (`json:"...,omitempty"`) normalizes that empty list to null — which is exactly what the tests expect (`None`). Foreign-key usage is populated as before.

Closes #48
