### PR TITLE
feat: allow previous behavior for geo types to be opted into

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -82,7 +82,15 @@ type connectionImpl struct {
 	activeTransaction     bool
 	useHighPrecision      bool
 	streamRetryEnabled    bool
+	geographyOutputFormat string
+	geometryOutputFormat  string
 	maxTimestampPrecision MaxTimestampPrecision
+}
+
+// useGeoArrow reports whether the EWKB peek/GeoArrow path should be used.
+// This is true when at least one of the geo output formats is EWKB.
+func (c *connectionImpl) useGeoArrow() bool {
+	return c.geographyOutputFormat == "EWKB" || c.geometryOutputFormat == "EWKB"
 }
 
 func escapeSingleQuoteForLike(arg string) string {
@@ -527,19 +535,27 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 			field.Type = arrow.FixedWidthTypes.Timestamp_ns
 		}
 	case "GEOGRAPHY":
-		// With GEOGRAPHY_OUTPUT_FORMAT=WKB, data arrives as binary WKB.
-		// GEOGRAPHY is always WGS84 (SRID 4326).
-		field.Type = arrow.BinaryTypes.Binary
-		field.Metadata = arrow.MetadataFrom(map[string]string{
-			"ARROW:extension:name":     "geoarrow.wkb",
-			"ARROW:extension:metadata": geographyGeoArrowJson,
-		})
+		if c.geographyOutputFormat == "GEOJSON" {
+			field.Type = arrow.BinaryTypes.String
+		} else {
+			// With GEOGRAPHY_OUTPUT_FORMAT=EWKB, data arrives as binary WKB.
+			// GEOGRAPHY is always WGS84 (SRID 4326).
+			field.Type = arrow.BinaryTypes.Binary
+			field.Metadata = arrow.MetadataFrom(map[string]string{
+				"ARROW:extension:name":     "geoarrow.wkb",
+				"ARROW:extension:metadata": geographyGeoArrowJson,
+			})
+		}
 	case "GEOMETRY":
-		// With GEOMETRY_OUTPUT_FORMAT=WKB, data arrives as binary WKB.
-		field.Type = arrow.BinaryTypes.Binary
-		field.Metadata = arrow.MetadataFrom(map[string]string{
-			"ARROW:extension:name": "geoarrow.wkb",
-		})
+		if c.geometryOutputFormat == "GEOJSON" {
+			field.Type = arrow.BinaryTypes.String
+		} else {
+			// With GEOMETRY_OUTPUT_FORMAT=EWKB, data arrives as binary WKB.
+			field.Type = arrow.BinaryTypes.Binary
+			field.Metadata = arrow.MetadataFrom(map[string]string{
+				"ARROW:extension:name": "geoarrow.wkb",
+			})
+		}
 	case "VECTOR":
 		// despite the fact that Snowflake *does* support returning data
 		// for VECTOR typed columns as Arrow FixedSizeLists, there's no way
@@ -550,7 +566,7 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 	return field
 }
 
-func descToField(name, typ, isnull, primary string, comment sql.NullString, useHighPrecision bool, maxTimestampPrecision MaxTimestampPrecision) (field arrow.Field, err error) {
+func descToField(name, typ, isnull, primary string, comment sql.NullString, useHighPrecision bool, maxTimestampPrecision MaxTimestampPrecision, geographyOutputFormat, geometryOutputFormat string) (field arrow.Field, err error) {
 	field.Name = name
 	if isnull == "Y" {
 		field.Nullable = true
@@ -585,16 +601,24 @@ func descToField(name, typ, isnull, primary string, comment sql.NullString, useH
 		case "VARIANT":
 			field.Type = arrow.BinaryTypes.String
 		case "GEOGRAPHY":
-			field.Type = arrow.BinaryTypes.Binary
-			field.Metadata = arrow.MetadataFrom(map[string]string{
-				"ARROW:extension:name":     "geoarrow.wkb",
-				"ARROW:extension:metadata": geographyGeoArrowJson,
-			})
+			if geographyOutputFormat == "GEOJSON" {
+				field.Type = arrow.BinaryTypes.String
+			} else {
+				field.Type = arrow.BinaryTypes.Binary
+				field.Metadata = arrow.MetadataFrom(map[string]string{
+					"ARROW:extension:name":     "geoarrow.wkb",
+					"ARROW:extension:metadata": geographyGeoArrowJson,
+				})
+			}
 		case "GEOMETRY":
-			field.Type = arrow.BinaryTypes.Binary
-			field.Metadata = arrow.MetadataFrom(map[string]string{
-				"ARROW:extension:name": "geoarrow.wkb",
-			})
+			if geometryOutputFormat == "GEOJSON" {
+				field.Type = arrow.BinaryTypes.String
+			} else {
+				field.Type = arrow.BinaryTypes.Binary
+				field.Metadata = arrow.MetadataFrom(map[string]string{
+					"ARROW:extension:name": "geoarrow.wkb",
+				})
+			}
 		case "BOOLEAN":
 			field.Type = arrow.FixedWidthTypes.Boolean
 		default:
@@ -762,7 +786,7 @@ func (c *connectionImpl) GetTableSchema(ctx context.Context, catalog *string, db
 		}
 
 		var f arrow.Field
-		f, err = descToField(name, typ, isnull, primary, comment, c.useHighPrecision, c.maxTimestampPrecision)
+		f, err = descToField(name, typ, isnull, primary, comment, c.useHighPrecision, c.maxTimestampPrecision, c.geographyOutputFormat, c.geometryOutputFormat)
 		if err != nil {
 			return nil, err
 		}

--- a/go/database.go
+++ b/go/database.go
@@ -89,6 +89,8 @@ type databaseImpl struct {
 
 	useHighPrecision      bool
 	streamRetryEnabled    bool
+	geographyOutputFormat string
+	geometryOutputFormat  string
 	maxTimestampPrecision MaxTimestampPrecision
 	defaultAppName        string
 }
@@ -176,6 +178,10 @@ func (d *databaseImpl) GetOption(ctx context.Context, key string) (string, error
 			return adbc.OptionValueEnabled, nil
 		}
 		return adbc.OptionValueDisabled, nil
+	case OptionGeographyOutputFormat:
+		return d.geographyOutputFormat, nil
+	case OptionGeometryOutputFormat:
+		return d.geometryOutputFormat, nil
 	case OptionMaxTimestampPrecision:
 		switch d.maxTimestampPrecision {
 		case Microseconds:
@@ -535,6 +541,16 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 				Code: adbc.StatusInvalidArgument,
 			}
 		}
+	case OptionGeographyOutputFormat:
+		if err := validateGeoOutputFormat(k, v); err != nil {
+			return err
+		}
+		d.geographyOutputFormat = strings.ToUpper(v)
+	case OptionGeometryOutputFormat:
+		if err := validateGeoOutputFormat(k, v); err != nil {
+			return err
+		}
+		d.geometryOutputFormat = strings.ToUpper(v)
 	case OptionMaxTimestampPrecision:
 		switch v {
 		case OptionValueNanoseconds, OptionValueNanosecondsNoOverflow, OptionValueMicroseconds:
@@ -553,24 +569,36 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 	return nil
 }
 
+func validateGeoOutputFormat(optionName, value string) error {
+	switch strings.ToUpper(value) {
+	case "EWKB", "GEOJSON":
+		return nil
+	default:
+		return adbc.Error{
+			Msg:  fmt.Sprintf("Invalid value for database option '%s': '%s' (must be 'EWKB' or 'GeoJSON')", optionName, value),
+			Code: adbc.StatusInvalidArgument,
+		}
+	}
+}
+
 func (d *databaseImpl) Open(ctx context.Context) (adbcConnection adbc.ConnectionWithContext, err error) {
 	ctx, span := driverbase.StartSpan(ctx, "databaseImpl.Open", d)
 	defer driverbase.EndSpan(span, err)
 
-	// Request EWKB so the SRID is encoded inline in every geometry value.
-	// The record reader peeks the first batch, lifts the SRID into geoarrow.wkb
-	// field metadata, and strips the EWKB prefix so consumers see plain ISO/OGC
-	// WKB. GEOGRAPHY is always WGS84 but we keep both formats in sync for a
-	// single decoding path.
+	// Set the Snowflake session output format for GEOGRAPHY/GEOMETRY based on
+	// the configured option. EWKB enables the GeoArrow path (binary + SRID
+	// peek); GeoJSON returns text strings. Only set the session parameter if
+	// the user hasn't already configured it directly via the Params map.
 	if d.cfg.Params == nil {
 		d.cfg.Params = make(map[string]*string)
 	}
-	ewkb := "EWKB"
 	if _, ok := d.cfg.Params["GEOGRAPHY_OUTPUT_FORMAT"]; !ok {
-		d.cfg.Params["GEOGRAPHY_OUTPUT_FORMAT"] = &ewkb
+		f := d.geographyOutputFormat
+		d.cfg.Params["GEOGRAPHY_OUTPUT_FORMAT"] = &f
 	}
 	if _, ok := d.cfg.Params["GEOMETRY_OUTPUT_FORMAT"]; !ok {
-		d.cfg.Params["GEOMETRY_OUTPUT_FORMAT"] = &ewkb
+		f := d.geometryOutputFormat
+		d.cfg.Params["GEOMETRY_OUTPUT_FORMAT"] = &f
 	}
 
 	connector := gosnowflake.NewConnector(drv, *d.cfg)
@@ -593,6 +621,8 @@ func (d *databaseImpl) Open(ctx context.Context) (adbcConnection adbc.Connection
 		// get Int64/Float64 instead
 		useHighPrecision:      d.useHighPrecision,
 		streamRetryEnabled:    d.streamRetryEnabled,
+		geographyOutputFormat: d.geographyOutputFormat,
+		geometryOutputFormat:  d.geometryOutputFormat,
 		maxTimestampPrecision: d.maxTimestampPrecision,
 		ConnectionImplBase:    driverbase.NewConnectionImplBase(&d.DatabaseImplBase),
 	}

--- a/go/driver.go
+++ b/go/driver.go
@@ -99,6 +99,18 @@ const (
 	// original inline streaming path. Default is disabled.
 	OptionStreamRetryEnabled = "adbc.snowflake.sql.client_option.stream_retry_enabled"
 
+	// OptionGeographyOutputFormat controls the output format for GEOGRAPHY
+	// columns. Valid values are "EWKB" and "GeoJSON" (default, case-insensitive).
+	// When set to EWKB, GEOGRAPHY columns are returned as geoarrow.wkb binary
+	// with CRS metadata. When set to GeoJSON, they are returned as UTF-8 text.
+	OptionGeographyOutputFormat = "adbc.snowflake.sql.client_option.geography_output_format"
+
+	// OptionGeometryOutputFormat controls the output format for GEOMETRY
+	// columns. Valid values are "EWKB" and "GeoJSON" (default, case-insensitive).
+	// When set to EWKB, GEOMETRY columns are returned as geoarrow.wkb binary
+	// with CRS metadata. When set to GeoJSON, they are returned as UTF-8 text.
+	OptionGeometryOutputFormat = "adbc.snowflake.sql.client_option.geometry_output_format"
+
 	OptionApplicationName  = "adbc.snowflake.sql.client_option.app_name"
 	OptionSSLSkipVerify    = "adbc.snowflake.sql.client_option.tls_skip_verify"
 	OptionOCSPFailOpenMode = "adbc.snowflake.sql.client_option.ocsp_fail_open_mode"
@@ -296,6 +308,8 @@ func (d *driverImpl) NewDatabaseWithOptionsContext(
 		DatabaseImplBase:      dbBase,
 		useHighPrecision:      true,
 		streamRetryEnabled:    false,
+		geographyOutputFormat: "GEOJSON",
+		geometryOutputFormat:  "GEOJSON",
 		defaultAppName:        defaultAppName,
 		maxTimestampPrecision: Nanoseconds,
 	}

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1818,6 +1818,76 @@ func (suite *SnowflakeTests) TestBooleanType() {
 	}
 }
 
+func (suite *SnowflakeTests) TestGeometryAsGeoArrow() {
+	// With geography/geometry output format set to EWKB: columns returned as geoarrow.wkb binary
+	opts := suite.Quirks.DatabaseOptions()
+	opts[driver.OptionGeographyOutputFormat] = "EWKB"
+	opts[driver.OptionGeometryOutputFormat] = "EWKB"
+
+	db, err := suite.driver.NewDatabaseWithContext(suite.ctx, opts)
+	suite.Require().NoError(err)
+	defer testutil.CheckedCloseWithContext(suite.T(), db, suite.ctx)
+
+	cnxn, err := db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	defer testutil.CheckedCloseWithContext(suite.T(), cnxn, suite.ctx)
+
+	stmt, err := cnxn.NewStatement(suite.ctx)
+	suite.Require().NoError(err)
+	defer testutil.CheckedCloseWithContext(suite.T(), stmt, suite.ctx)
+
+	suite.Require().NoError(stmt.SetSqlQuery(suite.ctx,
+		"SELECT TO_GEOGRAPHY('POINT(-122.35 47.62)') AS geog, TO_GEOMETRY('POINT(0 0)') AS geom"))
+	rdr, _, err := stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.True(rdr.Next())
+	rec := rdr.RecordBatch()
+
+	// GEOGRAPHY column should be binary with geoarrow.wkb extension
+	geogField := rec.Schema().Field(0)
+	suite.Equal(arrow.BINARY, geogField.Type.ID())
+	extName, ok := geogField.Metadata.GetValue("ARROW:extension:name")
+	suite.True(ok)
+	suite.Equal("geoarrow.wkb", extName)
+
+	// GEOMETRY column should also be binary with geoarrow.wkb extension
+	geomField := rec.Schema().Field(1)
+	suite.Equal(arrow.BINARY, geomField.Type.ID())
+	extName, ok = geomField.Metadata.GetValue("ARROW:extension:name")
+	suite.True(ok)
+	suite.Equal("geoarrow.wkb", extName)
+}
+
+func (suite *SnowflakeTests) TestGeometryAsText() {
+	// Default behavior (GeoJSON): GEOGRAPHY/GEOMETRY returned as UTF-8 strings
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx,
+		"SELECT TO_GEOGRAPHY('POINT(-122.35 47.62)') AS geog, TO_GEOMETRY('POINT(0 0)') AS geom"))
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.True(rdr.Next())
+	rec := rdr.RecordBatch()
+
+	// GEOGRAPHY column should be UTF-8 string
+	geogField := rec.Schema().Field(0)
+	suite.Equal(arrow.STRING, geogField.Type.ID())
+	_, hasExt := geogField.Metadata.GetValue("ARROW:extension:name")
+	suite.False(hasExt, "GeoJSON format should not set geoarrow extension metadata")
+
+	// GEOMETRY column should also be UTF-8 string
+	geomField := rec.Schema().Field(1)
+	suite.Equal(arrow.STRING, geomField.Type.ID())
+	_, hasExt = geomField.Metadata.GetValue("ARROW:extension:name")
+	suite.False(hasExt, "GeoJSON format should not set geoarrow extension metadata")
+
+	// Verify we get actual text data (GeoJSON format)
+	geogCol := rec.Column(0).(*array.String)
+	suite.Contains(geogCol.Value(0), "Point")
+}
+
 func (suite *SnowflakeTests) TestTimestampPrecisionJson() {
 	opts := suite.Quirks.DatabaseOptions()
 	opts[driver.OptionMaxTimestampPrecision] = "microseconds"

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -1122,7 +1122,7 @@ func readJSONBatches(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 	return array.NewRecordReader(schema, results)
 }
 
-func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake.ArrowStreamLoader, bufferSize, prefetchConcurrency int, useHighPrecision, streamRetryEnabled bool, maxTimestampPrecision MaxTimestampPrecision) (array.RecordReader, error) {
+func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake.ArrowStreamLoader, bufferSize, prefetchConcurrency int, useHighPrecision, streamRetryEnabled bool, maxTimestampPrecision MaxTimestampPrecision, useGeoArrow bool) (array.RecordReader, error) {
 	batches, err := ld.GetBatches()
 	if err != nil {
 		return nil, errToAdbcErr(adbc.StatusInternal, err)
@@ -1301,17 +1301,20 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		attribute.String("schema", rr.Schema().String()),
 	))
 
-	// Peek the first record from the first IPC batch so we can identify any
-	// binary columns that carry EWKB geometries (and lift their SRID into
-	// geoarrow.wkb field metadata) before fixing the result schema. The
-	// geometry shape is determined per-query from the data itself, so this
-	// works for any SQL — table scans, joins, CTEs, ST_Transform, etc. —
-	// without needing to parse the user's query text.
+	// When useGeoArrow is true (at least one geo output format is EWKB), peek
+	// the first record from the first IPC batch so we can identify any binary
+	// columns that carry EWKB geometries (and lift their SRID into
+	// geoarrow.wkb field metadata) before fixing the result schema. When
+	// useGeoArrow is false, skip the peek — geography/geometry columns arrive
+	// as text strings.
 	var firstRec arrow.RecordBatch
-	if rr.Next() {
-		firstRec = rr.RecordBatch()
+	var geoCols map[string]geoColumnInfo
+	if useGeoArrow {
+		if rr.Next() {
+			firstRec = rr.RecordBatch()
+		}
+		geoCols = analyzeGeoFromBatch(firstRec)
 	}
-	geoCols := analyzeGeoFromBatch(firstRec)
 
 	// Now setup concurrency primitives after error-prone operations
 	group, ctx := errgroup.WithContext(compute.WithAllocator(ctx, alloc))

--- a/go/statement.go
+++ b/go/statement.go
@@ -872,7 +872,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (reader array.RecordReade
 					return nil, err
 				}
 
-				reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision)
+				reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision, st.cnxn.useGeoArrow())
 				return reader, err
 			},
 			currentBatch: st.bound,
@@ -897,7 +897,7 @@ func (st *statement) ExecuteQuery(ctx context.Context) (reader array.RecordReade
 		return
 	}
 
-	reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision)
+	reader, err = newRecordReader(ctx, st.alloc, loader, st.queueSize, st.prefetchConcurrency, st.useHighPrecision, st.streamRetryEnabled, st.maxTimestampPrecision, st.cnxn.useGeoArrow())
 	nRows = loader.TotalRows()
 	return
 }


### PR DESCRIPTION
## What's Changed

#117 broke the behavior for geometry and geography types by changing the type of the returned data. This change adds a flag that allows the old behavior to be opted back into.