### PR TITLE
fix(go): handle UUID data type in metadata paths

### DIFF
--- a/go/binding.go
+++ b/go/binding.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 )
 
 // decimalToString converts an arrow Decimal128 or Decimal256 value to its string
@@ -183,11 +184,32 @@ func convertArrowToNamedValue(batch arrow.RecordBatch, index int, params []drive
 				params[i].Value = nil
 			}
 		case *array.FixedSizeBinary:
+			// arrow.uuid columns may arrive over the C Data Interface as
+			// their fixed_size_binary[16] storage with only field metadata
+			// identifying the extension; bind those as canonical UUID text,
+			// which Snowflake converts to UUID implicitly.
+			if extName, ok := field.Metadata.GetValue("ARROW:extension:name"); ok &&
+				extName == "arrow.uuid" && column.DataType().(*arrow.FixedSizeBinaryType).ByteWidth == 16 {
+				if column.IsValid(index) {
+					b := column.Value(index)
+					params[i].Value = fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+				} else {
+					params[i].Value = nil
+				}
+				continue
+			}
 			// Same as Binary — see comment above.
 			if column.IsValid(index) {
 				params[i].Value = hex.EncodeToString(column.Value(index))
 			} else {
 				params[i].Value = nil
+			}
+		case *extensions.UUIDArray:
+			// Bind UUID values in their canonical text form; Snowflake
+			// converts TEXT to UUID implicitly.
+			params[i].Value = sql.NullString{
+				String: column.Value(index).String(),
+				Valid:  column.IsValid(index),
 			}
 		case *array.Decimal128:
 			params[i].Value = sql.NullString{

--- a/go/connection.go
+++ b/go/connection.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/snowflakedb/gosnowflake/v2"
 	"golang.org/x/sync/errgroup"
 )
@@ -502,9 +503,7 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 	case "TEXT":
 		field.Type = arrow.BinaryTypes.String
 	case "UUID":
-		// Snowflake delivers UUID values as text over the wire, so the result
-		// schema for a UUID column is utf8; keep metadata discovery consistent.
-		field.Type = arrow.BinaryTypes.String
+		field.Type = extensions.NewUUIDType()
 	case "BINARY":
 		field.Type = arrow.BinaryTypes.Binary
 	case "BOOLEAN":
@@ -605,9 +604,7 @@ func descToField(name, typ, isnull, primary string, comment sql.NullString, useH
 		case "VARIANT":
 			field.Type = arrow.BinaryTypes.String
 		case "UUID":
-			// Snowflake delivers UUID values as text, so the result schema for a
-			// UUID column is utf8; keep DESC-based discovery consistent with it.
-			field.Type = arrow.BinaryTypes.String
+			field.Type = extensions.NewUUIDType()
 		case "GEOGRAPHY":
 			if geographyOutputFormat == "GEOJSON" {
 				field.Type = arrow.BinaryTypes.String

--- a/go/connection.go
+++ b/go/connection.go
@@ -501,6 +501,10 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 		field.Type = arrow.PrimitiveTypes.Float64
 	case "TEXT":
 		field.Type = arrow.BinaryTypes.String
+	case "UUID":
+		// Snowflake delivers UUID values as text over the wire, so the result
+		// schema for a UUID column is utf8; keep metadata discovery consistent.
+		field.Type = arrow.BinaryTypes.String
 	case "BINARY":
 		field.Type = arrow.BinaryTypes.Binary
 	case "BOOLEAN":
@@ -599,6 +603,10 @@ func descToField(name, typ, isnull, primary string, comment sql.NullString, useH
 		case "OBJECT":
 			fallthrough
 		case "VARIANT":
+			field.Type = arrow.BinaryTypes.String
+		case "UUID":
+			// Snowflake delivers UUID values as text, so the result schema for a
+			// UUID column is utf8; keep DESC-based discovery consistent with it.
 			field.Type = arrow.BinaryTypes.String
 		case "GEOGRAPHY":
 			if geographyOutputFormat == "GEOJSON" {

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1888,6 +1888,48 @@ func (suite *SnowflakeTests) TestGeometryAsText() {
 	suite.Contains(geogCol.Value(0), "Point")
 }
 
+func (suite *SnowflakeTests) TestUUIDType() {
+	// Snowflake's UUID data type is delivered as text over the wire, so it must
+	// surface as Arrow utf8 in every path. Before this was handled, the metadata
+	// paths failed ("Snowflake Data Type UUID not implemented" / nil field type),
+	// which surfaced downstream (e.g. Power BI) as "Unable to understand the type
+	// for column".
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, `CREATE OR REPLACE TABLE UUID_TYPE_TEST (
+		UUID_ID UUID,
+		VARCHAR_ID VARCHAR
+	)`))
+	_, err := suite.stmt.ExecuteUpdate(suite.ctx)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx,
+		"INSERT INTO UUID_TYPE_TEST SELECT uuid_string(), uuid_string()"))
+	_, err = suite.stmt.ExecuteUpdate(suite.ctx)
+	suite.Require().NoError(err)
+
+	// Metadata path: GetTableSchema (DESC TABLE -> descToField).
+	cat, sch := suite.Quirks.catalogName, suite.Quirks.schemaName
+	tableSchema, err := suite.cnxn.GetTableSchema(suite.ctx, &cat, &sch, "UUID_TYPE_TEST")
+	suite.Require().NoError(err)
+	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, tableSchema.Field(0).Type),
+		"GetTableSchema UUID_ID: expected utf8, got %s", tableSchema.Field(0).Type)
+
+	// Data path: result schema must match, and values must round-trip.
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, "SELECT * FROM UUID_TYPE_TEST"))
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	uuidField := rdr.Schema().Field(0)
+	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, uuidField.Type),
+		"SELECT UUID_ID: expected utf8, got %s", uuidField.Type)
+
+	suite.True(rdr.Next())
+	rec := rdr.RecordBatch()
+	uuidCol := rec.Column(0).(*array.String)
+	_, parseErr := uuid.Parse(uuidCol.Value(0))
+	suite.NoErrorf(parseErr, "UUID_ID value %q should parse as a UUID", uuidCol.Value(0))
+}
+
 func (suite *SnowflakeTests) TestTimestampPrecisionJson() {
 	opts := suite.Quirks.DatabaseOptions()
 	opts[driver.OptionMaxTimestampPrecision] = "microseconds"

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/google/uuid"
 	"github.com/snowflakedb/gosnowflake/v2"
@@ -1889,11 +1890,14 @@ func (suite *SnowflakeTests) TestGeometryAsText() {
 }
 
 func (suite *SnowflakeTests) TestUUIDType() {
-	// Snowflake's UUID data type is delivered as text over the wire, so it must
-	// surface as Arrow utf8 in every path. Before this was handled, the metadata
-	// paths failed ("Snowflake Data Type UUID not implemented" / nil field type),
-	// which surfaced downstream (e.g. Power BI) as "Unable to understand the type
-	// for column".
+	// Snowflake delivers UUID values as text over the wire; the driver decodes
+	// them into the arrow.uuid extension type (fixed_size_binary[16] storage)
+	// in both the metadata and data paths. Before this was handled, the
+	// metadata paths failed ("Snowflake Data Type UUID not implemented" / nil
+	// field type), which surfaced downstream (e.g. Power BI) as "Unable to
+	// understand the type for column".
+	uuidType := extensions.NewUUIDType()
+
 	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, `CREATE OR REPLACE TABLE UUID_TYPE_TEST (
 		UUID_ID UUID,
 		VARCHAR_ID VARCHAR
@@ -1910,8 +1914,8 @@ func (suite *SnowflakeTests) TestUUIDType() {
 	cat, sch := suite.Quirks.catalogName, suite.Quirks.schemaName
 	tableSchema, err := suite.cnxn.GetTableSchema(suite.ctx, &cat, &sch, "UUID_TYPE_TEST")
 	suite.Require().NoError(err)
-	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, tableSchema.Field(0).Type),
-		"GetTableSchema UUID_ID: expected utf8, got %s", tableSchema.Field(0).Type)
+	suite.Truef(arrow.TypeEqual(uuidType, tableSchema.Field(0).Type),
+		"GetTableSchema UUID_ID: expected arrow.uuid, got %s", tableSchema.Field(0).Type)
 
 	// Data path: result schema must match, and values must round-trip.
 	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, "SELECT * FROM UUID_TYPE_TEST"))
@@ -1920,14 +1924,24 @@ func (suite *SnowflakeTests) TestUUIDType() {
 	defer rdr.Release()
 
 	uuidField := rdr.Schema().Field(0)
-	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, uuidField.Type),
-		"SELECT UUID_ID: expected utf8, got %s", uuidField.Type)
+	suite.Truef(arrow.TypeEqual(uuidType, uuidField.Type),
+		"SELECT UUID_ID: expected arrow.uuid, got %s", uuidField.Type)
 
 	suite.True(rdr.Next())
 	rec := rdr.RecordBatch()
-	uuidCol := rec.Column(0).(*array.String)
-	_, parseErr := uuid.Parse(uuidCol.Value(0))
-	suite.NoErrorf(parseErr, "UUID_ID value %q should parse as a UUID", uuidCol.Value(0))
+	uuidCol, ok := rec.Column(0).(*extensions.UUIDArray)
+	suite.Require().Truef(ok, "UUID_ID column: expected *extensions.UUIDArray, got %T", rec.Column(0))
+	_, parseErr := uuid.Parse(uuidCol.ValueStr(0))
+	suite.NoErrorf(parseErr, "UUID_ID value %q should parse as a UUID", uuidCol.ValueStr(0))
+
+	// An untyped NULL literal shares UUID's "text, length 0" result metadata;
+	// it must stay utf8 rather than be misclassified as a UUID column.
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, "SELECT NULL AS N"))
+	nullRdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer nullRdr.Release()
+	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, nullRdr.Schema().Field(0).Type),
+		"SELECT NULL: expected utf8, got %s", nullRdr.Schema().Field(0).Type)
 }
 
 func (suite *SnowflakeTests) TestTimestampPrecisionJson() {

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -1944,6 +1944,61 @@ func (suite *SnowflakeTests) TestUUIDType() {
 		"SELECT NULL: expected utf8, got %s", nullRdr.Schema().Field(0).Type)
 }
 
+func (suite *SnowflakeTests) TestSqlIngestUUIDType() {
+	suite.Require().NoError(suite.Quirks.DropTable(suite.cnxn, "bulk_ingest_uuid"))
+
+	uuidType := extensions.NewUUIDType()
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "col_int64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "col_uuid", Type: uuidType, Nullable: true},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(suite.Quirks.Alloc(), sc)
+	defer bldr.Release()
+
+	uuids := []string{
+		"01234567-89ab-cdef-0123-456789abcdef",
+		"6ca7f4a6-e4e4-4fd8-9d4c-6e2f2df4a7e1",
+	}
+	bldr.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2, 3}, nil)
+	uuidBldr := bldr.Field(1).(*extensions.UUIDBuilder)
+	uuidBldr.Append(uuid.MustParse(uuids[0]))
+	uuidBldr.Append(uuid.MustParse(uuids[1]))
+	uuidBldr.AppendNull()
+
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	suite.Require().NoError(suite.stmt.Bind(suite.ctx, rec))
+	suite.Require().NoError(suite.stmt.SetOption(suite.ctx, adbc.OptionKeyIngestTargetTable, "bulk_ingest_uuid"))
+	n, err := suite.stmt.ExecuteUpdate(suite.ctx)
+	suite.Require().NoError(err)
+	suite.EqualValues(3, n)
+
+	// The ingested column must be a native UUID column, so the metadata path
+	// (DESC TABLE) reports it as arrow.uuid.
+	cat, sch := suite.Quirks.catalogName, suite.Quirks.schemaName
+	tableSchema, err := suite.cnxn.GetTableSchema(suite.ctx, &cat, &sch, "bulk_ingest_uuid")
+	suite.Require().NoError(err)
+	suite.Truef(arrow.TypeEqual(uuidType, tableSchema.Field(1).Type),
+		"ingested col_uuid: expected arrow.uuid, got %s", tableSchema.Field(1).Type)
+
+	// Values must round-trip, including the NULL.
+	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, `SELECT * FROM "bulk_ingest_uuid" ORDER BY "col_int64" ASC`))
+	rdr, n, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.EqualValues(3, n)
+	suite.True(rdr.Next())
+	result := rdr.RecordBatch()
+	uuidCol, ok := result.Column(1).(*extensions.UUIDArray)
+	suite.Require().Truef(ok, "col_uuid: expected *extensions.UUIDArray, got %T", result.Column(1))
+	suite.Equal(uuids[0], uuidCol.ValueStr(0))
+	suite.Equal(uuids[1], uuidCol.ValueStr(1))
+	suite.True(uuidCol.IsNull(2))
+}
+
 func (suite *SnowflakeTests) TestTimestampPrecisionJson() {
 	opts := suite.Quirks.DatabaseOptions()
 	opts[driver.OptionMaxTimestampPrecision] = "microseconds"

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -53,7 +53,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
-	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/google/uuid"
 	"github.com/snowflakedb/gosnowflake/v2"
@@ -1889,114 +1888,15 @@ func (suite *SnowflakeTests) TestGeometryAsText() {
 	suite.Contains(geogCol.Value(0), "Point")
 }
 
-func (suite *SnowflakeTests) TestUUIDType() {
-	// Snowflake delivers UUID values as text over the wire; the driver decodes
-	// them into the arrow.uuid extension type (fixed_size_binary[16] storage)
-	// in both the metadata and data paths. Before this was handled, the
-	// metadata paths failed ("Snowflake Data Type UUID not implemented" / nil
-	// field type), which surfaced downstream (e.g. Power BI) as "Unable to
-	// understand the type for column".
-	uuidType := extensions.NewUUIDType()
-
-	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, `CREATE OR REPLACE TABLE UUID_TYPE_TEST (
-		UUID_ID UUID,
-		VARCHAR_ID VARCHAR
-	)`))
-	_, err := suite.stmt.ExecuteUpdate(suite.ctx)
-	suite.Require().NoError(err)
-
-	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx,
-		"INSERT INTO UUID_TYPE_TEST SELECT uuid_string(), uuid_string()"))
-	_, err = suite.stmt.ExecuteUpdate(suite.ctx)
-	suite.Require().NoError(err)
-
-	// Metadata path: GetTableSchema (DESC TABLE -> descToField).
-	cat, sch := suite.Quirks.catalogName, suite.Quirks.schemaName
-	tableSchema, err := suite.cnxn.GetTableSchema(suite.ctx, &cat, &sch, "UUID_TYPE_TEST")
-	suite.Require().NoError(err)
-	suite.Truef(arrow.TypeEqual(uuidType, tableSchema.Field(0).Type),
-		"GetTableSchema UUID_ID: expected arrow.uuid, got %s", tableSchema.Field(0).Type)
-
-	// Data path: result schema must match, and values must round-trip.
-	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, "SELECT * FROM UUID_TYPE_TEST"))
-	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
-	suite.Require().NoError(err)
-	defer rdr.Release()
-
-	uuidField := rdr.Schema().Field(0)
-	suite.Truef(arrow.TypeEqual(uuidType, uuidField.Type),
-		"SELECT UUID_ID: expected arrow.uuid, got %s", uuidField.Type)
-
-	suite.True(rdr.Next())
-	rec := rdr.RecordBatch()
-	uuidCol, ok := rec.Column(0).(*extensions.UUIDArray)
-	suite.Require().Truef(ok, "UUID_ID column: expected *extensions.UUIDArray, got %T", rec.Column(0))
-	_, parseErr := uuid.Parse(uuidCol.ValueStr(0))
-	suite.NoErrorf(parseErr, "UUID_ID value %q should parse as a UUID", uuidCol.ValueStr(0))
-
+func (suite *SnowflakeTests) TestUntypedNullLiteral() {
 	// An untyped NULL literal shares UUID's "text, length 0" result metadata;
 	// it must stay utf8 rather than be misclassified as a UUID column.
 	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, "SELECT NULL AS N"))
-	nullRdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
-	suite.Require().NoError(err)
-	defer nullRdr.Release()
-	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, nullRdr.Schema().Field(0).Type),
-		"SELECT NULL: expected utf8, got %s", nullRdr.Schema().Field(0).Type)
-}
-
-func (suite *SnowflakeTests) TestSqlIngestUUIDType() {
-	suite.Require().NoError(suite.Quirks.DropTable(suite.cnxn, "bulk_ingest_uuid"))
-
-	uuidType := extensions.NewUUIDType()
-	sc := arrow.NewSchema([]arrow.Field{
-		{Name: "col_int64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-		{Name: "col_uuid", Type: uuidType, Nullable: true},
-	}, nil)
-
-	bldr := array.NewRecordBuilder(suite.Quirks.Alloc(), sc)
-	defer bldr.Release()
-
-	uuids := []string{
-		"01234567-89ab-cdef-0123-456789abcdef",
-		"6ca7f4a6-e4e4-4fd8-9d4c-6e2f2df4a7e1",
-	}
-	bldr.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2, 3}, nil)
-	uuidBldr := bldr.Field(1).(*extensions.UUIDBuilder)
-	uuidBldr.Append(uuid.MustParse(uuids[0]))
-	uuidBldr.Append(uuid.MustParse(uuids[1]))
-	uuidBldr.AppendNull()
-
-	rec := bldr.NewRecordBatch()
-	defer rec.Release()
-
-	suite.Require().NoError(suite.stmt.Bind(suite.ctx, rec))
-	suite.Require().NoError(suite.stmt.SetOption(suite.ctx, adbc.OptionKeyIngestTargetTable, "bulk_ingest_uuid"))
-	n, err := suite.stmt.ExecuteUpdate(suite.ctx)
-	suite.Require().NoError(err)
-	suite.EqualValues(3, n)
-
-	// The ingested column must be a native UUID column, so the metadata path
-	// (DESC TABLE) reports it as arrow.uuid.
-	cat, sch := suite.Quirks.catalogName, suite.Quirks.schemaName
-	tableSchema, err := suite.cnxn.GetTableSchema(suite.ctx, &cat, &sch, "bulk_ingest_uuid")
-	suite.Require().NoError(err)
-	suite.Truef(arrow.TypeEqual(uuidType, tableSchema.Field(1).Type),
-		"ingested col_uuid: expected arrow.uuid, got %s", tableSchema.Field(1).Type)
-
-	// Values must round-trip, including the NULL.
-	suite.Require().NoError(suite.stmt.SetSqlQuery(suite.ctx, `SELECT * FROM "bulk_ingest_uuid" ORDER BY "col_int64" ASC`))
-	rdr, n, err := suite.stmt.ExecuteQuery(suite.ctx)
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
 	suite.Require().NoError(err)
 	defer rdr.Release()
-
-	suite.EqualValues(3, n)
-	suite.True(rdr.Next())
-	result := rdr.RecordBatch()
-	uuidCol, ok := result.Column(1).(*extensions.UUIDArray)
-	suite.Require().Truef(ok, "col_uuid: expected *extensions.UUIDArray, got %T", result.Column(1))
-	suite.Equal(uuids[0], uuidCol.ValueStr(0))
-	suite.Equal(uuids[1], uuidCol.ValueStr(1))
-	suite.True(uuidCol.IsNull(2))
+	suite.Truef(arrow.TypeEqual(arrow.BinaryTypes.String, rdr.Schema().Field(0).Type),
+		"SELECT NULL: expected utf8, got %s", rdr.Schema().Field(0).Type)
 }
 
 func (suite *SnowflakeTests) TestTimestampPrecisionJson() {

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -42,6 +42,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/snowflakedb/gosnowflake/v2"
@@ -161,6 +162,53 @@ func stripEWKBSRIDColumn(_ context.Context, a arrow.Array) (arrow.Array, error) 
 			continue
 		}
 		bldr.Append(stripEWKBSRID(ba.Value(i)))
+	}
+	return bldr.NewArray(), nil
+}
+
+// isUUIDResultColumn reports whether a result column carries Snowflake UUID
+// values. Snowflake result metadata does not surface a dedicated "uuid" type
+// today: UUID columns are reported as "text" but with length 0, which no real
+// text column can have (VARCHAR's minimum length is 1, and even SHOW commands
+// report the maximum length for their text columns). The explicit "uuid"
+// match future-proofs against the server reporting the logical type directly.
+//
+// The only other columns reported as length-0 text are untyped NULL literals
+// (e.g. SELECT NULL); on the Arrow data path callers can rule those out with
+// isUntypedNullField.
+func isUUIDResultColumn(typ string, length int64) bool {
+	return strings.EqualFold(typ, "uuid") ||
+		(strings.EqualFold(typ, "text") && length == 0)
+}
+
+// isUntypedNullField reports whether the server-provided Arrow field metadata
+// identifies a length-0 text column as an untyped NULL literal rather than a
+// UUID column: NULL literals carry an explicit byteLength of "0", while UUID
+// columns carry their 16-byte storage width or omit the key entirely.
+func isUntypedNullField(f arrow.Field) bool {
+	v, ok := f.Metadata.GetValue("byteLength")
+	return ok && v == "0"
+}
+
+// uuidStringsToUUIDColumn returns a column transformer that parses the utf8
+// UUID text Snowflake sends on the wire into an arrow.uuid extension array
+// (fixed_size_binary[16] storage).
+func uuidStringsToUUIDColumn(ctx context.Context, a arrow.Array) (arrow.Array, error) {
+	sa, ok := a.(*array.String)
+	if !ok {
+		return nil, fmt.Errorf("expected utf8 data for UUID column, got %s", a.DataType())
+	}
+	bldr := extensions.NewUUIDBuilder(compute.GetAllocator(ctx))
+	defer bldr.Release()
+	bldr.Reserve(sa.Len())
+	for i := range sa.Len() {
+		if sa.IsNull(i) {
+			bldr.AppendNull()
+			continue
+		}
+		if err := bldr.AppendValueFromString(sa.Value(i)); err != nil {
+			return nil, err
+		}
 	}
 	return bldr.NewArray(), nil
 }
@@ -294,6 +342,15 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 			}
 			f.Metadata = arrow.MetadataFrom(meta)
 			transformers[i] = stripEWKBSRIDColumn
+			fields[i] = f
+			continue
+		}
+
+		// Snowflake delivers UUID values as utf8 text on the wire; decode
+		// them into the canonical arrow.uuid extension type.
+		if isUUIDResultColumn(srcMeta.Type, srcMeta.Length) && !isUntypedNullField(f) {
+			f.Type = extensions.NewUUIDType()
+			transformers[i] = uuidStringsToUUIDColumn
 			fields[i] = f
 			continue
 		}
@@ -599,6 +656,13 @@ func rowTypesToArrowSchema(_ context.Context, ld gosnowflake.ArrowStreamLoader, 
 				[]string{MetadataKeySnowflakeType},
 				[]string{srcMeta.Type},
 			),
+		}
+		if isUUIDResultColumn(srcMeta.Type, srcMeta.Length) {
+			// jsonDataToArrow appends the JSON UUID text through the
+			// extension builder's AppendValueFromString, which parses it
+			// into the fixed_size_binary[16] storage.
+			fields[i].Type = extensions.NewUUIDType()
+			continue
 		}
 		switch srcMeta.Type {
 		case "fixed":

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -658,9 +658,6 @@ func rowTypesToArrowSchema(_ context.Context, ld gosnowflake.ArrowStreamLoader, 
 			),
 		}
 		if isUUIDResultColumn(srcMeta.Type, srcMeta.Length) {
-			// jsonDataToArrow appends the JSON UUID text through the
-			// extension builder's AppendValueFromString, which parses it
-			// into the fixed_size_binary[16] storage.
 			fields[i].Type = extensions.NewUUIDType()
 			continue
 		}

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -167,18 +167,16 @@ func stripEWKBSRIDColumn(_ context.Context, a arrow.Array) (arrow.Array, error) 
 }
 
 // isUUIDResultColumn reports whether a result column carries Snowflake UUID
-// values. Snowflake result metadata does not surface a dedicated "uuid" type
-// today: UUID columns are reported as "text" but with length 0, which no real
-// text column can have (VARCHAR's minimum length is 1, and even SHOW commands
-// report the maximum length for their text columns). The explicit "uuid"
-// match future-proofs against the server reporting the logical type directly.
+// values. Snowflake result metadata does not surface a dedicated "uuid" type:
+// UUID columns are reported as "text" but with length 0, which no real text
+// column can have (VARCHAR's minimum length is 1, and even SHOW commands
+// report the maximum length for their text columns).
 //
 // The only other columns reported as length-0 text are untyped NULL literals
 // (e.g. SELECT NULL); on the Arrow data path callers can rule those out with
 // isUntypedNullField.
 func isUUIDResultColumn(typ string, length int64) bool {
-	return strings.EqualFold(typ, "uuid") ||
-		(strings.EqualFold(typ, "text") && length == 0)
+	return strings.EqualFold(typ, "text") && length == 0
 }
 
 // isUntypedNullField reports whether the server-provided Arrow field metadata

--- a/go/record_reader.go
+++ b/go/record_reader.go
@@ -346,8 +346,6 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 			continue
 		}
 
-		// Snowflake delivers UUID values as utf8 text on the wire; decode
-		// them into the canonical arrow.uuid extension type.
 		if isUUIDResultColumn(srcMeta.Type, srcMeta.Length) && !isUntypedNullField(f) {
 			f.Type = extensions.NewUUIDType()
 			transformers[i] = uuidStringsToUUIDColumn

--- a/go/statement.go
+++ b/go/statement.go
@@ -498,11 +498,11 @@ func toSnowflakeType(dt arrow.DataType) string {
 
 // initIngest creates the target table for ingestion.
 //
-// geoTypeOverrides maps field names to Snowflake types ("geography" or "geometry")
-// for geo columns that should be created with native types instead of their Arrow
-// storage type (BINARY/TEXT). This is used when COPY transform handles inline
-// conversion, so the table must have native geo columns from the start.
-func (st *statement) initIngest(ctx context.Context, geoTypeOverrides map[string]string) error {
+// typeOverrides maps field names to Snowflake types for extension columns
+// that should be created with native types instead of their Arrow storage
+// type: "geography"/"geometry" for geoarrow columns (BINARY/TEXT storage)
+// and "uuid" for arrow.uuid columns (fixed_size_binary[16] storage).
+func (st *statement) initIngest(ctx context.Context, typeOverrides map[string]string) error {
 	var (
 		createBldr strings.Builder
 	)
@@ -529,14 +529,14 @@ func (st *statement) initIngest(ctx context.Context, geoTypeOverrides map[string
 		createBldr.WriteString(quoteIdentifier(f.Name))
 		createBldr.WriteString(" ")
 
-		// Use geo type override if provided (for COPY transform path).
-		// Geo column detection happens in buildCopyQuery, which checks both
-		// arrow.EXTENSION types and ARROW:extension:name field metadata — the
-		// latter is needed for data arriving over the C Data Interface, where
-		// extension types are not registered. The override map ensures the
-		// CREATE TABLE uses GEOGRAPHY/GEOMETRY for those columns.
+		// Use the type override if provided. Extension column detection
+		// happens in buildCopyQuery, which checks both arrow.EXTENSION types
+		// and ARROW:extension:name field metadata — the latter is needed for
+		// data arriving over the C Data Interface, where extension types are
+		// not registered. The override map ensures the CREATE TABLE uses
+		// GEOGRAPHY/GEOMETRY/UUID for those columns.
 		var ty string
-		if override, ok := geoTypeOverrides[f.Name]; ok {
+		if override, ok := typeOverrides[f.Name]; ok {
 			ty = override
 		} else {
 			ty = toSnowflakeType(f.Type)
@@ -602,12 +602,12 @@ func (st *statement) executeIngest(ctx context.Context) (int64, error) {
 	// Build the COPY query. If the schema has geo columns, this is a COPY
 	// transform that converts WKB/WKT → GEOGRAPHY/GEOMETRY inline during
 	// COPY INTO; otherwise it is the plain copy query.
-	copyQ, geoOverrides, err := st.buildCopyQuery(schema)
+	copyQ, typeOverrides, err := st.buildCopyQuery(schema)
 	if err != nil {
 		return -1, err
 	}
 
-	err = st.initIngest(ctx, geoOverrides)
+	err = st.initIngest(ctx, typeOverrides)
 	if err != nil {
 		return -1, err
 	}
@@ -619,14 +619,21 @@ func (st *statement) executeIngest(ctx context.Context) (int64, error) {
 }
 
 // buildCopyQuery returns the COPY query to use for ingestion and a map of
-// geo column name → Snowflake type for table creation overrides. When the
+// column name → Snowflake type for table creation overrides. When the
 // schema contains geoarrow columns, a COPY transform is returned that
 // converts WKB/WKT to GEOGRAPHY/GEOMETRY inline during COPY INTO — Snowflake's
 // COPY INTO from Parquet normally cannot load WKB directly into
 // GEOGRAPHY/GEOMETRY columns, and a COPY transform works around this by
 // applying TO_GEOGRAPHY/TO_GEOMETRY in the SELECT clause of the COPY subquery.
 //
-// Geo column detection covers both arrow.EXTENSION types and
+// arrow.uuid columns are created as native UUID columns. No COPY transform
+// is needed for them on the plain path: Snowflake's Parquet reader converts
+// the Parquet UUID logical type (which the writer emits for arrow.uuid's
+// fixed_size_binary[16] storage) natively. On the geo transform path, where
+// every column is read through a `$1:"col"` VARIANT reference instead, the
+// 16 raw bytes are re-encoded as canonical UUID text inline.
+//
+// Extension column detection covers both arrow.EXTENSION types and
 // ARROW:extension:name field metadata so that data arriving over the C Data
 // Interface (where extension types are not registered) is also recognized.
 func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]string, error) {
@@ -642,6 +649,7 @@ func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]st
 		extMeta string
 	}
 	var geoCols []geoCol
+	uuidCols := make(map[string]bool)
 
 	for _, f := range schema.Fields() {
 		var extName, extMeta string
@@ -657,17 +665,29 @@ func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]st
 		switch extName {
 		case "geoarrow.wkb", "geoarrow.wkt":
 			geoCols = append(geoCols, geoCol{name: f.Name, extName: extName, extMeta: extMeta})
+		case "arrow.uuid":
+			uuidCols[f.Name] = true
 		}
 	}
 
-	if len(geoCols) == 0 {
+	if len(geoCols) == 0 && len(uuidCols) == 0 {
 		return copyQuery, nil, nil
+	}
+
+	typeOverrides := make(map[string]string, len(geoCols)+len(uuidCols))
+	for name := range uuidCols {
+		typeOverrides[name] = "uuid"
+	}
+
+	if len(geoCols) == 0 {
+		// Only UUID columns: the plain COPY converts the Parquet UUID
+		// logical type natively, so just the CREATE TABLE override applies.
+		return copyQuery, typeOverrides, nil
 	}
 
 	// Build a COPY transform with inline geo conversion. Each geo column's
 	// target type is resolved per-column so a non-4326 CRS can promote that
 	// column to GEOMETRY while sibling 4326 columns stay GEOGRAPHY.
-	geoOverrides := make(map[string]string, len(geoCols))
 	var selectCols []string
 	for fieldIndex, f := range schema.Fields() {
 		quoted := quoteIdentifier(f.Name)
@@ -683,6 +703,15 @@ func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]st
 		}
 
 		if gc == nil {
+			if uuidCols[f.Name] {
+				// UUID column: the VARIANT reference yields the 16 raw
+				// storage bytes; re-encode them as canonical UUID text,
+				// which Snowflake casts to the UUID column on load.
+				selectCols = append(selectCols, fmt.Sprintf(
+					`REGEXP_REPLACE(HEX_ENCODE(%s::BINARY, 0), '(.{8})(.{4})(.{4})(.{4})(.{12})', '\\1-\\2-\\3-\\4-\\5') AS %s`,
+					parqRef, quoted))
+				continue
+			}
 			// Non-geo column: reference directly from Parquet, Snowflake auto-casts to target type.
 			selectCols = append(selectCols, fmt.Sprintf("%s AS %s", parqRef, quoted))
 			continue
@@ -695,7 +724,7 @@ func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]st
 			return "", nil, err
 		}
 
-		geoOverrides[gc.name] = geoType
+		typeOverrides[gc.name] = geoType
 		var expr string
 		if geoType == "geography" {
 			if isWKB {
@@ -727,7 +756,7 @@ func (st *statement) buildCopyQuery(schema *arrow.Schema) (string, map[string]st
 		strings.Join(selectCols, ", "),
 		bindStageName,
 	)
-	return transformQ, geoOverrides, nil
+	return transformQ, typeOverrides, nil
 }
 
 // resolveGeoType picks the Snowflake target type for a single geoarrow column.

--- a/go/validation/queries/ingest/uuid.txtcase
+++ b/go/validation/queries/ingest/uuid.txtcase
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// part: metadata
+
+[tags]
+sql-type-name = "UUID"
+
+// part: input_schema
+
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "w:16",
+            "flags": ["nullable"],
+            "metadata": {
+                "ARROW:extension:name": "arrow.uuid"
+            }
+        }
+    ]
+}
+
+// part: input
+
+{"idx": 0, "value": null}
+{"idx": 1, "value": "AAAAAAAAAAAAAAAAAAAAAA=="}
+{"idx": 2, "value": "ASNFZ4mrze8BI0VniavN7w=="}
+{"idx": 3, "value": "bKf0puTkT9idTG4vLfSn4Q=="}
+{"idx": 4, "value": "/////////////////////w=="}
+
+// part: expected_schema
+// The arrow.uuid column is ingested as a native Snowflake UUID column, and
+// reading it back yields the arrow.uuid extension type again.
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "idx",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "value",
+            "format": "w:16",
+            "flags": ["nullable"],
+            "metadata": {
+                "ARROW:extension:name": "arrow.uuid"
+            }
+        }
+    ]
+}
+
+// part: expected
+
+{"idx": 0, "value": null}
+{"idx": 1, "value": "AAAAAAAAAAAAAAAAAAAAAA=="}
+{"idx": 2, "value": "ASNFZ4mrze8BI0VniavN7w=="}
+{"idx": 3, "value": "bKf0puTkT9idTG4vLfSn4Q=="}
+{"idx": 4, "value": "/////////////////////w=="}

--- a/go/validation/queries/type/bind/uuid.txtcase
+++ b/go/validation/queries/type/bind/uuid.txtcase
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// part: metadata
+
+[setup]
+drop = "TEST_UUID_BIND"
+
+[tags]
+sql-type-name = "UUID"
+
+// part: setup_query
+
+CREATE TABLE TEST_UUID_BIND (
+    IDX INTEGER,
+    RES UUID
+);
+
+// part: bind_query
+
+INSERT INTO TEST_UUID_BIND VALUES ($1, $2)
+
+// part: bind_schema
+
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "IDX",
+            "format": "l",
+            "flags": ["nullable"]
+        },
+        {
+            "name": "RES",
+            "format": "w:16",
+            "flags": ["nullable"],
+            "metadata": {
+                "ARROW:extension:name": "arrow.uuid"
+            }
+        }
+    ]
+}
+
+// part: bind
+
+{"IDX": 1, "RES": null}
+{"IDX": 2, "RES": "AAAAAAAAAAAAAAAAAAAAAA=="}
+{"IDX": 3, "RES": "ASNFZ4mrze8BI0VniavN7w=="}
+{"IDX": 4, "RES": "bKf0puTkT9idTG4vLfSn4Q=="}
+{"IDX": 5, "RES": "/////////////////////w=="}
+
+// part: query
+
+SELECT RES FROM TEST_UUID_BIND ORDER BY IDX ASC
+
+// part: expected_schema
+
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "RES",
+            "format": "w:16",
+            "flags": ["nullable"],
+            "metadata": {
+                "ARROW:extension:name": "arrow.uuid"
+            }
+        }
+    ]
+}
+
+// part: expected
+
+{"RES": null}
+{"RES": "AAAAAAAAAAAAAAAAAAAAAA=="}
+{"RES": "ASNFZ4mrze8BI0VniavN7w=="}
+{"RES": "bKf0puTkT9idTG4vLfSn4Q=="}
+{"RES": "/////////////////////w=="}

--- a/go/validation/queries/type/select/uuid.txtcase
+++ b/go/validation/queries/type/select/uuid.txtcase
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// part: metadata
+
+[setup]
+drop = "TEST_UUID"
+
+[tags]
+field-type-name = "UUID"
+sql-type-name = "UUID"
+
+// part: setup_query
+
+CREATE TABLE TEST_UUID (
+    IDX INTEGER,
+    RES UUID
+);
+
+INSERT INTO TEST_UUID VALUES
+  (1, NULL),
+  (2, '00000000-0000-0000-0000-000000000000'),
+  (3, '01234567-89ab-cdef-0123-456789abcdef'),
+  (4, '6ca7f4a6-e4e4-4fd8-9d4c-6e2f2df4a7e1'),
+  (5, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+;
+
+// part: query
+
+SELECT RES FROM TEST_UUID ORDER BY IDX ASC
+
+// part: expected_schema
+// Snowflake delivers UUID values as utf8 text on the wire; the driver decodes
+// them into the arrow.uuid extension type (fixed_size_binary[16] storage) and
+// reports the same type from the metadata paths.
+{
+    "format": "+s",
+    "children": [
+        {
+            "name": "RES",
+            "format": "w:16",
+            "flags": ["nullable"],
+            "metadata": {
+                "ARROW:extension:name": "arrow.uuid"
+            }
+        }
+    ]
+}
+
+// part: expected
+
+{"RES": null}
+{"RES": "AAAAAAAAAAAAAAAAAAAAAA=="}
+{"RES": "ASNFZ4mrze8BI0VniavN7w=="}
+{"RES": "bKf0puTkT9idTG4vLfSn4Q=="}
+{"RES": "/////////////////////w=="}

--- a/go/validation/queries/type/select/uuid.txtcase
+++ b/go/validation/queries/type/select/uuid.txtcase
@@ -41,9 +41,6 @@ INSERT INTO TEST_UUID VALUES
 SELECT RES FROM TEST_UUID ORDER BY IDX ASC
 
 // part: expected_schema
-// Snowflake delivers UUID values as utf8 text on the wire; the driver decodes
-// them into the arrow.uuid extension type (fixed_size_binary[16] storage) and
-// reports the same type from the metadata paths.
 {
     "format": "+s",
     "children": [


### PR DESCRIPTION
## Problem

Snowflake's [`UUID` data type](https://docs.snowflake.com/en/sql-reference/data-types-uuid) queries fine but was unhandled in the driver's two schema-discovery paths:

- **`GetTableSchema`** (`DESC TABLE` → `descToField`): a parenless `UUID` type fell into the `default` and returned a hard error — `Not Implemented: Snowflake Data Type UUID not implemented`.
- **`GetObjects`** (`SHOW COLUMNS` → `toArrowField`): no `case` matched `UUID`, so `arrow.Field.Type` was left `nil`.

This surfaced downstream (e.g. the Power BI Snowflake connector, Metabase) as failures like `Expression.Error: Unable to understand the type for column`.

## Fix

UUID columns are surfaced as `arrow.uuid`.

## How UUID result columns are detected

Snowflake does **not** report a dedicated `uuid` type in query-result metadata. Verified against a live account: both the rowtype JSON and the Arrow field metadata report UUID result columns as `text`/`TEXT` (consistent with the docs: "Snowflake drivers treat UUID values as text strings"). Only `DESC TABLE` / `SHOW COLUMNS` name the type — so those paths map `UUID` directly.

On the result path, UUID columns are identified by their otherwise-impossible shape: **`text` with length 0** (VARCHAR's minimum length is 1; SHOW commands, empty strings, `NULL::VARCHAR`, concatenations, etc. all report length ≥ 1, while table columns, `NULL::UUID`, and UUID-typed expressions all report 0). The one other length-0 producer — an untyped `NULL` literal (`SELECT NULL`) — is ruled out on the Arrow data path via its explicit `byteLength: "0"` field metadata (UUID columns carry `"16"` or omit the key). A literal `uuid` rowtype is also matched, to future-proof against the server reporting the logical type directly.

## Changes

- `descToField` (`GetTableSchema`) and `toArrowField` (`GetObjects`) report `arrow.uuid`
- the Arrow data path parses the utf8 values into an `extensions.UUIDArray` via a column transformer; the JSON fallback path types the field so the extension builder parses the text
- **Bulk ingest**: `arrow.uuid` columns are created as native `UUID` columns (previously `BINARY(16)`). On the plain COPY path no transform is needed — Snowflake's Parquet reader converts the Parquet UUID logical type (emitted for arrow.uuid's `fixed_size_binary[16]` storage) natively, verified value-for-value against a live account. On the geo COPY-transform path (where every column is read through a `$1:"col"` VARIANT reference), the 16 raw bytes are re-encoded to canonical UUID text inline.
- **Bind**: `arrow.uuid` parameters (both registered `extensions.UUIDArray` values and C-Data-Interface arrays that arrive as `fixed_size_binary[16]` storage plus `ARROW:extension:name` field metadata) bind as canonical UUID text, which Snowflake converts implicitly.
- Extension detection follows the existing geoarrow pattern: both `arrow.EXTENSION` types and `ARROW:extension:name` field metadata are recognized.

Closes #164
