### PR TITLE
fix(go): geo type auto-detect should not require edges:spherical for GEOGRAPHY

### DIFF
--- a/go/docs/snowflake.md
+++ b/go/docs/snowflake.md
@@ -366,7 +366,7 @@ Examples:
 `adbc.snowflake.statement.ingest_geo_type`
 : **Values:** `geography`, `geometry`, or empty string. **Default:** empty string
 
-  Which Snowflake data type to use when ingesting columns of GeoArrow extension types (`geoarrow.wkb`, `geoarrow.wkt`). If empty, then it will be detected: if the SRID is 4326 and `edges:spherical` is set, then it will be ingested as GEOGRAPHY, else GEOMETRY. If explicitly set, the driver will use the specified type.
+  Which Snowflake data type to use when ingesting columns of GeoArrow extension types (`geoarrow.wkb`, `geoarrow.wkt`). If empty, the type is detected per column from the CRS metadata: columns with SRID 4326 (or no CRS at all) are ingested as GEOGRAPHY, columns with any other SRID as GEOMETRY (so the SRID survives the round trip), and `edges:spherical` combined with a non-4326 SRID is an error. Most GeoArrow producers (e.g. DuckDB, GeoPandas) emit a `crs` but no `edges` field, so detection does not require `edges:spherical` for WGS84 data. If explicitly set, the driver uses the specified type for all GeoArrow columns.
 
   Can be set on the statement.
 

--- a/go/statement.go
+++ b/go/statement.go
@@ -740,9 +740,7 @@ func (opts *ingestOptions) resolveGeoType(fieldIndex int, fieldName string, extM
 		return opts.geoType, nil
 	}
 	srid, edges := extractSRIDFromMeta(extMeta)
-	if srid == 4326 && edges == "spherical" {
-		return "geography", nil
-	} else if edges == "spherical" {
+	if edges == "spherical" && srid != 0 && srid != 4326 {
 		// Snowflake GEOGRAPHY is always SRID 4326, so if the user
 		// specified spherical edges but a different SRID, we should
 		// error/ask them to explicitly set the geo type
@@ -750,6 +748,14 @@ func (opts *ingestOptions) resolveGeoType(fieldIndex int, fieldName string, extM
 			Msg:  fmt.Sprintf("[snowflake] field #%d (%s) is a GeoArrow array with spherical edges but an SRID of %d; Snowflake GEOGRAPHY is always SRID 4326, so explicitly set %s to choose whether to ingest this as GEOGRAPHY or GEOMETRY", fieldIndex+1, quoteIdentifier(fieldName), srid, OptionStatementIngestGeoType),
 			Code: adbc.StatusInvalidData,
 		}
+	}
+	// Missing CRS, EPSG:4326, or an unparsable CRS defaults to GEOGRAPHY, as
+	// documented above — most GeoArrow producers (e.g. DuckDB) emit a crs but
+	// no "edges" field, and requiring edges == "spherical" would silently
+	// demote WGS84 data to GEOMETRY. Only a concrete non-4326 SRID promotes
+	// the column so the SRID survives the round trip.
+	if srid == 0 || srid == 4326 {
+		return "geography", nil
 	}
 	return "geometry", nil
 }

--- a/go/statement_test.go
+++ b/go/statement_test.go
@@ -222,9 +222,13 @@ func TestExtractSRIDFromMeta(t *testing.T) {
 func TestResolveGeoType(t *testing.T) {
 	opts := &ingestOptions{}
 
+	// EPSG:4326 without an "edges" field stays GEOGRAPHY: most GeoArrow
+	// producers (DuckDB, GeoPandas) emit a crs but no edges, and WGS84 data
+	// should not silently demote to GEOMETRY (matches the documented
+	// contract of resolveGeoType).
 	ty, err := opts.resolveGeoType(0, "geom", `{"crs":"EPSG:4326"}`)
 	assert.NoError(t, err)
-	assert.Equal(t, "geometry", ty)
+	assert.Equal(t, "geography", ty)
 
 	ty, err = opts.resolveGeoType(0, "geom", `{"crs":"EPSG:3857"}`)
 	assert.NoError(t, err)
@@ -237,13 +241,15 @@ func TestResolveGeoType(t *testing.T) {
 	_, err = opts.resolveGeoType(0, "geom", `{"crs":"EPSG:3857", "edges":"spherical"}`)
 	assert.ErrorContains(t, err, `field #1 ("geom") is a GeoArrow array with spherical edges`)
 
+	// Missing or empty CRS metadata also stays GEOGRAPHY per the documented
+	// default.
 	ty, err = opts.resolveGeoType(0, "geom", "")
 	assert.NoError(t, err)
-	assert.Equal(t, "geometry", ty)
+	assert.Equal(t, "geography", ty)
 
 	ty, err = opts.resolveGeoType(0, "geom", "{}")
 	assert.NoError(t, err)
-	assert.Equal(t, "geometry", ty)
+	assert.Equal(t, "geography", ty)
 
 	// explicit geoType should override CRS-derived default
 	opts.geoType = "geometry"


### PR DESCRIPTION
`resolveGeoType`'s own doc comment says *"missing CRS, EPSG:4326, or unparsable CRS stays GEOGRAPHY"*, and `docs/snowflake.md`'s option table described detection differently again — but the implementation required `edges == "spherical"` in addition to SRID 4326 before choosing GEOGRAPHY.

Most GeoArrow producers emit a `crs` but **no `edges` field** (DuckDB's spatial extension and GeoPandas among them), so in practice every WGS84 column ingested through auto-detect silently landed as GEOMETRY. We hit this in CARTO's integration suite when moving from the pre-merge #117 branch to `go/v1.11.0`: same import, `GEOGRAPHY` became `GEOMETRY`.

This aligns the code with the documented contract:

- SRID 4326 **or no CRS** → GEOGRAPHY
- any other SRID → GEOMETRY (SRID survives the round trip via ST_SETSRID)
- `edges:spherical` with a non-4326 SRID → still an error (unchanged)
- explicit `adbc.snowflake.statement.ingest_geo_type` → unchanged, pins all columns

Updated `TestResolveGeoType` and the option docs to match. The two auto-detect validation txtcases are unaffected (the GEOGRAPHY one uses 4326+spherical, the GEOMETRY one uses EPSG:2029).

https://claude.ai/code/session_01Y3xqZXWrx9qXdPNXBzNxa2