### PR TITLE
fix(go): scope SHOW COLUMNS to the requested object in GetObjects

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -125,8 +125,10 @@ func getQueryID(ctx context.Context, query string, driverConn driver.QueryerCont
 	rows, err := driverConn.QueryContext(ctx, query, nil)
 	if err != nil {
 		var sfErr *gosnowflake.SnowflakeError
-		// No results. Generate a dummy result set instead
-		if emptyQuery != "" && errors.As(err, &sfErr) && sfErr.Number == 2043 {
+		// 2043: the SHOW command matched nothing. 2003: the scoped object does
+		// not exist or is not authorized. In both cases substitute an empty
+		// result set so RESULT_SCAN has a valid (empty) source to read from.
+		if emptyQuery != "" && errors.As(err, &sfErr) && (sfErr.Number == 2043 || sfErr.Number == 2003) {
 			return getQueryID(ctx, emptyQuery, driverConn, "")
 		}
 		return "", err
@@ -191,6 +193,43 @@ func goGetQueryID(ctx context.Context, conn driver.QueryerContext, grp *errgroup
 
 func isWildcardStr(ident string) bool {
 	return strings.ContainsAny(ident, "_%")
+}
+
+// scopeIdentifier reports whether ident can be used as a concrete object name to
+// narrow a SHOW command's scope (IN DATABASE/SCHEMA/TABLE). Only the
+// multi-character wildcard '%' and the match-all sentinels force a broader
+// scope; a '_' is treated as a literal character. Treating '_' as a wildcard
+// here would scope SHOW COLUMNS to IN ACCOUNT for ordinary names like
+// "DB_NAME", scanning every column in the entire account; the downstream ILIKE
+// filtering in the query template still applies the pattern semantics.
+func scopeIdentifier(ident *string) (string, bool) {
+	if ident == nil {
+		return "", false
+	}
+	s := *ident
+	if s == "" || s == "%" || s == ".*" || strings.Contains(s, "%") {
+		return "", false
+	}
+	return s, true
+}
+
+// showColumnsScope returns the narrowest "IN ..." suffix for the SHOW COLUMNS
+// query given the requested catalog/schema/table, avoiding an account-wide
+// column scan whenever concrete names are provided.
+func showColumnsScope(catalog, dbSchema, tableName *string) string {
+	cat, ok := scopeIdentifier(catalog)
+	if !ok {
+		return " IN ACCOUNT"
+	}
+	sch, ok := scopeIdentifier(dbSchema)
+	if !ok {
+		return " IN DATABASE " + quoteIdentifier(cat)
+	}
+	tbl, ok := scopeIdentifier(tableName)
+	if !ok {
+		return " IN SCHEMA " + quoteIdentifier(cat) + "." + quoteIdentifier(sch)
+	}
+	return " IN TABLE " + quoteIdentifier(cat) + "." + quoteIdentifier(sch) + "." + quoteIdentifier(tbl)
 }
 
 func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth, catalog, dbSchema, tableName, columnName *string, tableType []string) (reader array.RecordReader, err error) {
@@ -295,8 +334,9 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 			return err
 		})
 
+		columnsSuffix := showColumnsScope(catalog, dbSchema, tableName)
 		gQueryIDs.Go(func() (err error) {
-			columnsQueryID, err = getQueryID(gQueryIDsCtx, "SHOW COLUMNS /* ADBC:getObjects */"+suffix, conn, "SHOW COLUMNS /* ADBC:getObjects */ LIKE '' IN ACCOUNT")
+			columnsQueryID, err = getQueryID(gQueryIDsCtx, "SHOW COLUMNS /* ADBC:getObjects */"+columnsSuffix, conn, "SHOW COLUMNS /* ADBC:getObjects */ LIKE '' IN ACCOUNT")
 			return err
 		})
 

--- a/go/connection.go
+++ b/go/connection.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -121,14 +122,23 @@ func escapeSingleQuoteForLike(arg string) string {
 	}
 }
 
-func getQueryID(ctx context.Context, query string, driverConn driver.QueryerContext, emptyQuery string) (string, error) {
+const (
+	// Snowflake error numbers signalling a SHOW produced no usable result set.
+	errShowNoMatch    = 2043 // the SHOW command matched nothing
+	errObjectNotFound = 2003 // the scoped object does not exist or is not authorized
+)
+
+func getQueryID(ctx context.Context, query string, driverConn driver.QueryerContext, emptyQuery string, alsoEmptyOn ...int) (string, error) {
 	rows, err := driverConn.QueryContext(ctx, query, nil)
 	if err != nil {
 		var sfErr *gosnowflake.SnowflakeError
-		// 2043: the SHOW command matched nothing. 2003: the scoped object does
-		// not exist or is not authorized. In both cases substitute an empty
-		// result set so RESULT_SCAN has a valid (empty) source to read from.
-		if emptyQuery != "" && errors.As(err, &sfErr) && (sfErr.Number == 2043 || sfErr.Number == 2003) {
+		// errShowNoMatch always maps to an empty result. Callers running an
+		// optional, narrowly-scoped SHOW may also pass errObjectNotFound so a
+		// missing scoped object degrades to an empty result instead of failing
+		// the whole GetObjects call. Substitute emptyQuery so RESULT_SCAN has a
+		// valid (empty) source to read from.
+		if emptyQuery != "" && errors.As(err, &sfErr) &&
+			(sfErr.Number == errShowNoMatch || slices.Contains(alsoEmptyOn, sfErr.Number)) {
 			return getQueryID(ctx, emptyQuery, driverConn, "")
 		}
 		return "", err
@@ -196,12 +206,11 @@ func isWildcardStr(ident string) bool {
 }
 
 // scopeIdentifier reports whether ident can be used as a concrete object name to
-// narrow a SHOW command's scope (IN DATABASE/SCHEMA/TABLE). Only the
-// multi-character wildcard '%' and the match-all sentinels force a broader
-// scope; a '_' is treated as a literal character. Treating '_' as a wildcard
-// here would scope SHOW COLUMNS to IN ACCOUNT for ordinary names like
-// "DB_NAME", scanning every column in the entire account; the downstream ILIKE
-// filtering in the query template still applies the pattern semantics.
+// narrow the scope of the SHOW COLUMNS enrichment query (IN DATABASE/SCHEMA/
+// TABLE). It deliberately treats '_' as a literal character rather than an ADBC
+// single-character wildcard: only '%', the match-all sentinels, and nil force a
+// broader scope. See showColumnsScope for why treating '_' literally here is
+// safe despite the ADBC pattern semantics.
 func scopeIdentifier(ident *string) (string, bool) {
 	if ident == nil {
 		return "", false
@@ -214,8 +223,17 @@ func scopeIdentifier(ident *string) (string, bool) {
 }
 
 // showColumnsScope returns the narrowest "IN ..." suffix for the SHOW COLUMNS
-// query given the requested catalog/schema/table, avoiding an account-wide
-// column scan whenever concrete names are provided.
+// query. SHOW COLUMNS cannot be filtered by table, so an IN ACCOUNT scope scans
+// every column in the account (80+ seconds on large accounts).
+//
+// The result feeds get_objects_all.sql ONLY as a best-effort source for BINARY
+// xdbc_column_size enrichment; the authoritative column list comes from
+// information_schema.columns filtered by ILIKE, so a narrower scope here can
+// never drop columns or alter non-BINARY metadata. The sole consequence of
+// treating '_' as a literal (see scopeIdentifier) is that a BINARY column
+// reached only through '_'-as-wildcard matches, or through a case-insensitive
+// pattern that differs from the stored identifier, may report a NULL
+// xdbc_column_size, matching the behavior before this enrichment was added.
 func showColumnsScope(catalog, dbSchema, tableName *string) string {
 	cat, ok := scopeIdentifier(catalog)
 	if !ok {
@@ -336,7 +354,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 
 		columnsSuffix := showColumnsScope(catalog, dbSchema, tableName)
 		gQueryIDs.Go(func() (err error) {
-			columnsQueryID, err = getQueryID(gQueryIDsCtx, "SHOW COLUMNS /* ADBC:getObjects */"+columnsSuffix, conn, "SHOW COLUMNS /* ADBC:getObjects */ LIKE '' IN ACCOUNT")
+			columnsQueryID, err = getQueryID(gQueryIDsCtx, "SHOW COLUMNS /* ADBC:getObjects */"+columnsSuffix, conn, "SHOW COLUMNS /* ADBC:getObjects */ LIKE '' IN ACCOUNT", errObjectNotFound)
 			return err
 		})
 

--- a/go/get_objects_scope_test.go
+++ b/go/get_objects_scope_test.go
@@ -25,6 +25,7 @@ func TestShowColumnsScope(t *testing.T) {
 		want                   string
 	}{
 		{"concrete names with underscores scope to the table", sp("DB_NAME"), sp("TEST_SCHEMA"), sp("LINEITEM"), ` IN TABLE "DB_NAME"."TEST_SCHEMA"."LINEITEM"`},
+		{"underscore is treated as a literal, not a single-char wildcard", sp("FOO_BAR"), sp("SCH"), sp("TBL"), ` IN TABLE "FOO_BAR"."SCH"."TBL"`},
 		{"wildcard table scopes to the schema", sp("DB_NAME"), sp("TEST_SCHEMA"), sp("%"), ` IN SCHEMA "DB_NAME"."TEST_SCHEMA"`},
 		{"nil schema scopes to the database", sp("DB_NAME"), nil, nil, ` IN DATABASE "DB_NAME"`},
 		{"nil catalog falls back to account", nil, nil, nil, " IN ACCOUNT"},

--- a/go/get_objects_scope_test.go
+++ b/go/get_objects_scope_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 ADBC Drivers Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake
+
+import "testing"
+
+func TestShowColumnsScope(t *testing.T) {
+	sp := func(s string) *string { return &s }
+
+	tests := []struct {
+		name                   string
+		catalog, schema, table *string
+		want                   string
+	}{
+		{"concrete names with underscores scope to the table", sp("DB_NAME"), sp("TEST_SCHEMA"), sp("LINEITEM"), ` IN TABLE "DB_NAME"."TEST_SCHEMA"."LINEITEM"`},
+		{"wildcard table scopes to the schema", sp("DB_NAME"), sp("TEST_SCHEMA"), sp("%"), ` IN SCHEMA "DB_NAME"."TEST_SCHEMA"`},
+		{"nil schema scopes to the database", sp("DB_NAME"), nil, nil, ` IN DATABASE "DB_NAME"`},
+		{"nil catalog falls back to account", nil, nil, nil, " IN ACCOUNT"},
+		{"percent catalog falls back to account", sp("%"), sp("S"), sp("T"), " IN ACCOUNT"},
+		{"catalog containing percent falls back to account", sp("DB_%"), nil, nil, " IN ACCOUNT"},
+		{"dot-star catalog falls back to account", sp(".*"), nil, nil, " IN ACCOUNT"},
+		{"empty catalog falls back to account", sp(""), nil, nil, " IN ACCOUNT"},
+		{"percent in table scopes to the schema", sp("DB"), sp("SCH"), sp("LINE%"), ` IN SCHEMA "DB"."SCH"`},
+		{"embedded quote is escaped", sp(`DB"X`), sp("S"), sp("T"), ` IN TABLE "DB""X"."S"."T"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := showColumnsScope(tt.catalog, tt.schema, tt.table); got != tt.want {
+				t.Errorf("showColumnsScope() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #169.

`GetObjects` at `ObjectDepthColumns` / `ObjectDepthAll` dispatched a `SHOW COLUMNS` command whose scope resolved to `IN ACCOUNT` whenever the catalog name contained an underscore, because `isWildcardStr` treats `_` and `%` as wildcards. Since `SHOW COLUMNS` has no table-level `LIKE` filter, `SHOW COLUMNS ... IN ACCOUNT` scans every column in the entire account — 80–150s on large accounts — even for a single-table request like `DB_NAME.TEST_SCHEMA.LINEITEM`.

## Changes

- Add `scopeIdentifier` / `showColumnsScope` and scope the `SHOW COLUMNS` query to the narrowest concrete object (`IN TABLE` / `IN SCHEMA` / `IN DATABASE`), treating `_` as a literal and only `%` / `.*` / nil as broadening.
- Limit the `2003` (object does not exist / not authorized) empty-result fallback to only the optional `SHOW COLUMNS` enrichment query, via a new variadic `alsoEmptyOn` parameter on `getQueryID`. Required object/constraint discovery keeps its prior `2043`-only behavior.
- Add a unit test for scope selection.

## Why this is safe

`SHOW COLUMNS` is only a best-effort source for BINARY `xdbc_column_size` in `get_objects_all.sql` (a `LEFT JOIN` for `byte_length`). The authoritative column list comes from `information_schema.columns` filtered by `ILIKE`, so a narrower `SHOW COLUMNS` scope never drops columns or alters non-BINARY metadata.

**Tradeoff:** a BINARY column reached only through a genuine `_`-as-wildcard match (or a case-insensitive pattern differing from the stored identifier) may report a NULL `xdbc_column_size`, matching the behavior before `SHOW COLUMNS` enrichment was added in #152. This is documented on `scopeIdentifier` / `showColumnsScope`.

## Scope timing (small test account; worse on large accounts)

| `SHOW COLUMNS` scope | Elapsed |
|---|---|
| `IN ACCOUNT` | 18.4 s |
| `IN DATABASE` | 4.8 s |
| `IN SCHEMA` | 0.52 s |
| `IN TABLE` | 0.39 s |

## Testing

- `go build`, `go vet`, `gofmt`: clean.
- `TestShowColumnsScope`: passes (concrete underscore names → `IN TABLE`; `%` / `.*` / nil → broader; quote escaping).
- Live check against a real account: `GetObjects(Columns, "SNOWFLAKE_SAMPLE_DATA", "TPCH_SF1", "LINEITEM")` returns correctly and drops from the ~18s `IN ACCOUNT` floor to a table-scoped query; a non-existent table returns an empty result rather than erroring.
