### PR TITLE
feat(go): add proxy-specific properties

### DIFF
--- a/go/database.go
+++ b/go/database.go
@@ -530,13 +530,14 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 	case OptionProxyHost:
 		d.cfg.ProxyHost = v
 	case OptionProxyPort:
-		d.cfg.ProxyPort, err = strconv.Atoi(v)
-		if err != nil {
+		port, parseErr := strconv.Atoi(v)
+		if parseErr != nil || port <= 0 || port > 65535 {
 			return adbc.Error{
-				Msg:  "error encountered parsing proxy port option: " + err.Error(),
+				Msg:  fmt.Sprintf("Invalid value for database option '%s': '%s' (must be an integer between 1 and 65535)", k, v),
 				Code: adbc.StatusInvalidArgument,
 			}
 		}
+		d.cfg.ProxyPort = port
 	case OptionProxyUser:
 		d.cfg.ProxyUser = v
 	case OptionProxyPassword:

--- a/go/database.go
+++ b/go/database.go
@@ -168,6 +168,16 @@ func (d *databaseImpl) GetOption(ctx context.Context, key string) (string, error
 		return d.cfg.Tracing, nil //nolint:staticcheck,nolintlint // ignore snowflake deprecated warnings for now
 	case OptionClientConfigFile:
 		return d.cfg.ClientConfigFile, nil
+	case OptionProxyHost:
+		return d.cfg.ProxyHost, nil
+	case OptionProxyPort:
+		return strconv.Itoa(d.cfg.ProxyPort), nil
+	case OptionProxyUser:
+		return d.cfg.ProxyUser, nil
+	case OptionProxyPassword:
+		return d.cfg.ProxyPassword, nil
+	case OptionProxyProtocol:
+		return d.cfg.ProxyProtocol, nil
 	case OptionUseHighPrecision:
 		if d.useHighPrecision {
 			return adbc.OptionValueEnabled, nil
@@ -517,6 +527,30 @@ func (d *databaseImpl) SetOptionInternal(k string, v string, cnOptions *map[stri
 		d.cfg.Tracing = v //nolint:staticcheck,nolintlint // ignore snowflake deprecated warnings for now
 	case OptionClientConfigFile:
 		d.cfg.ClientConfigFile = v
+	case OptionProxyHost:
+		d.cfg.ProxyHost = v
+	case OptionProxyPort:
+		d.cfg.ProxyPort, err = strconv.Atoi(v)
+		if err != nil {
+			return adbc.Error{
+				Msg:  "error encountered parsing proxy port option: " + err.Error(),
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
+	case OptionProxyUser:
+		d.cfg.ProxyUser = v
+	case OptionProxyPassword:
+		d.cfg.ProxyPassword = v
+	case OptionProxyProtocol:
+		switch strings.ToLower(v) {
+		case "http", "https":
+			d.cfg.ProxyProtocol = strings.ToLower(v)
+		default:
+			return adbc.Error{
+				Msg:  fmt.Sprintf("Invalid value for database option '%s': '%s'", k, v),
+				Code: adbc.StatusInvalidArgument,
+			}
+		}
 	case OptionUseHighPrecision:
 		switch v {
 		case adbc.OptionValueEnabled:

--- a/go/docs/snowflake.md
+++ b/go/docs/snowflake.md
@@ -225,6 +225,32 @@ Examples:
   The native Okta URL (for example, `https://<org>.okta.com`) used for SSO when
   `adbc.snowflake.sql.auth_type` is `auth_okta`.
 
+`adbc.snowflake.sql.client_option.proxy_host`
+: **Type:** string
+
+  The proxy server hostname or IP address. If omitted, no explicit proxy is
+  configured and gosnowflake uses its default proxy behavior.
+
+`adbc.snowflake.sql.client_option.proxy_port`
+: **Type:** int
+
+  The proxy server port.
+
+`adbc.snowflake.sql.client_option.proxy_protocol`
+: **Values:** `http` or `https`. **Default:** `http`
+
+  The protocol used to connect to the proxy server.
+
+`adbc.snowflake.sql.client_option.proxy_user`
+: **Type:** string
+
+  The username used for proxy authentication.
+
+`adbc.snowflake.sql.client_option.proxy_password`
+: **Type:** string
+
+  The password used for proxy authentication.
+
 `adbc.snowflake.sql.client_option.request_timeout`
 : **Type:** duration string (e.g. `300ms`, `1.5s`, or `1m30s`)
 

--- a/go/driver.go
+++ b/go/driver.go
@@ -134,6 +134,12 @@ const (
 	OptionLogTracing = "adbc.snowflake.sql.client_option.tracing"
 	// snowflake driver client logging config file
 	OptionClientConfigFile = "adbc.snowflake.sql.client_option.config_file"
+	// snowflake driver proxy configuration
+	OptionProxyHost     = "adbc.snowflake.sql.client_option.proxy_host"
+	OptionProxyPort     = "adbc.snowflake.sql.client_option.proxy_port"
+	OptionProxyUser     = "adbc.snowflake.sql.client_option.proxy_user"
+	OptionProxyPassword = "adbc.snowflake.sql.client_option.proxy_password"
+	OptionProxyProtocol = "adbc.snowflake.sql.client_option.proxy_protocol"
 	// When true, the MFA token is cached in the credential manager. True by default
 	// on Windows/OSX, false for Linux
 	OptionClientRequestMFAToken = "adbc.snowflake.sql.client_option.cache_mfa_token"

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -2835,6 +2835,75 @@ func (suite *SnowflakeTests) TestGetSetClientConfigFile() {
 	suite.True(file == result)
 }
 
+func TestProxyOptions(t *testing.T) {
+	ctx := context.Background()
+	adbcDriver := driver.NewDriver(memory.DefaultAllocator)
+	options := map[string]string{
+		driver.OptionProxyHost:     "my.proxy.com",
+		driver.OptionProxyPort:     "8080",
+		driver.OptionProxyUser:     "myProxyUser",
+		driver.OptionProxyPassword: "my_password",
+		driver.OptionProxyProtocol: "HTTPS",
+	}
+
+	db, err := adbcDriver.NewDatabaseWithContext(ctx, options)
+	require.NoError(t, err)
+	defer testutil.CheckedCloseWithContext(t, db, ctx)
+
+	getSetDB, ok := db.(adbc.GetSetOptionsWithContext)
+	require.True(t, ok)
+
+	expected := map[string]string{
+		driver.OptionProxyHost:     "my.proxy.com",
+		driver.OptionProxyPort:     "8080",
+		driver.OptionProxyUser:     "myProxyUser",
+		driver.OptionProxyPassword: "my_password",
+		driver.OptionProxyProtocol: "https",
+	}
+	for key, value := range expected {
+		actual, err := getSetDB.GetOption(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, value, actual)
+	}
+}
+
+func TestProxyHostDefaultsToEmpty(t *testing.T) {
+	ctx := context.Background()
+	adbcDriver := driver.NewDriver(memory.DefaultAllocator)
+	db, err := adbcDriver.NewDatabaseWithContext(ctx, nil)
+	require.NoError(t, err)
+	defer testutil.CheckedCloseWithContext(t, db, ctx)
+
+	getSetDB, ok := db.(adbc.GetSetOptionsWithContext)
+	require.True(t, ok)
+	host, err := getSetDB.GetOption(ctx, driver.OptionProxyHost)
+	require.NoError(t, err)
+	require.Empty(t, host)
+}
+
+func TestInvalidProxyOptions(t *testing.T) {
+	ctx := context.Background()
+	adbcDriver := driver.NewDriver(memory.DefaultAllocator)
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "port", key: driver.OptionProxyPort, value: "not-a-port"},
+		{name: "protocol", key: driver.OptionProxyProtocol, value: "socks5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := adbcDriver.NewDatabaseWithContext(ctx, map[string]string{tt.key: tt.value})
+			require.Error(t, err)
+			var adbcErr adbc.Error
+			require.ErrorAs(t, err, &adbcErr)
+			require.Equal(t, adbc.StatusInvalidArgument, adbcErr.Code)
+		})
+	}
+}
+
 func (suite *SnowflakeTests) TestGetObjectsWithNilCatalog() {
 	// this test demonstrates calling GetObjects with the catalog depth and a nil catalog
 	rdr, err := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthCatalogs, nil, nil, nil, nil, nil)


### PR DESCRIPTION
## What's Changed

You *can* use a proxy today if you pass the `uri` property with the appropriate values like:

```
uri = "mysnowflakeuser:mysnowflakepass@myaccount?proxyHost=127.0.0.1&proxyPort=8080&proxyUser=myuser&proxyPassword=mypass&proxyProtocol=http"
```
This requires passing some dummy username/password, but is still valid for other auth types.

This PR adds the ability to provide the proxy values explicitly without having to rely on parsing the DSN value (which just so happens to be the first thing that is done today when `SetOptions` is called).
